### PR TITLE
docs: correct UCG-Max device name, port terminology, zone-based firewall model

### DIFF
--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -39,24 +39,45 @@ subnet as-is and just add VLANs 20/21/30 as the new ones — the exact Trusted
 subnet doesn't matter, what matters is that Prod/Dev/Mgmt are separate
 VLANs from it and from each other.
 
-## Step 2: Assign Physical Ports
+## Step 2: Proxmox Bridge Configuration (DO THIS FIRST)
 
-Under **Settings → Networks → Port Manager** (or per-port config on the
-UCG-Fiber's switch ports):
+Before cabling, configure the Proxmox bridge as **VLAN-aware** so VM
+network interfaces with `tag=` actually receive the correct VLAN:
 
-- Pick one LAN port and tag it for VLAN 20 (Prod) — this is where the R740's
-  first NIC port connects
-- Pick another LAN port and tag it for VLAN 21 (Dev) — R740's second NIC port
-- Pick another and tag it for VLAN 30 (Mgmt) — R740's third NIC port (or
-  iDRAC's dedicated port, if your R740 has a separate iDRAC NIC — check
-  the back of the chassis; if iDRAC has its own port, use that for VLAN 30
-  instead of consuming a 4th data NIC port for it)
-- Leave remaining ports on the default Trusted-LAN VLAN for your existing
-  devices
+```bash
+# On the Proxmox host, edit /etc/network/interfaces
+# Add bridge-vlan-aware yes to vmbr0:
+auto vmbr0
+iface vmbr0 inet manual
+    bridge-ports eno1
+    bridge-stp off
+    bridge-fd 0
+    bridge-vlan-aware yes
+    bridge-vids 10 20 21 30
+# After editing, apply:
+ifreload -a
+```
 
-This uses 3 of the R740's 4 onboard RJ45 ports (Prod, Dev, Mgmt), leaving
-1 spare — fine for now, gives you headroom for a future LACP bond or a
-second Mgmt path later if you want it.
+**Without this setting, VLAN tags on VM network interfaces are silently
+ignored and both VMs fall onto the same untagged broadcast domain —
+breaking the entire inter-VLAN security model with no visible symptom.**
+
+## Step 3: Assign the UCG-Fiber Port as a Trunk
+
+Use a single LAN port on the UCG-Fiber configured as a **trunk port**
+carrying all four VLANs tagged:
+
+- Pick one UCG-Fiber LAN port and set it to carry VLANs 10, 20, 21, 30
+  tagged (802.1Q trunk)
+- Connect the R740's vmbr0 physical port (eno1 or equivalent) to this
+  UCG-Fiber trunk port
+- The remaining three R740 NIC ports are free for future LACP bonding,
+  a dedicated management path, or a failover link
+
+**Important:** This is a trunk-port topology — one cable, multiple tagged
+VLANs. Do NOT configure three separate access ports. The VM NIC config
+uses `tag=20` and `tag=21` which emit 802.1Q-tagged frames. An access
+port would drop them.
 
 ## Step 3: Firewall Rules — Inter-VLAN Isolation
 

--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -1,21 +1,46 @@
-# UCG-Fiber Network Configuration Guide
+# UCG-Max Network Configuration Guide
 
-This covers the UniFi OS setup on the UCG-Fiber: 4 VLANs, firewall rules,
-and port forwards. All of this is done through the UniFi web UI (or the
-UniFi mobile app) — there is no CLI scripting for this device in this kit,
-since Ubiquiti doesn't expose a stable local API/CLI for this scope of config
-without extra tooling. Follow this as a manual checklist.
+**Device correction (2026-08-11):** this guide previously referred to a
+"UCG-Fiber" throughout. The actual hardware in this deployment is a
+**UCG-Max** (UCG-Max-NS) — a different Ubiquiti product with different
+ports and throughput. Confirmed via Ubiquiti's own tech-specs page
+(techspecs.ui.com/unifi/cloud-gateways/ucg-max): 5x 2.5GbE RJ45 ports
+total, 1 default WAN port (up to 4 can be configured as WAN if ever
+needed), 2.3 Gbps IDS/IPS throughput. If you have an actual UCG-Fiber
+instead, the steps below are still broadly correct (same UniFi Network
+application, same UI concepts) but re-check your device's real port
+count and WAN handoff type (Fiber's default WAN is SFP+/fiber, not
+2.5GbE RJ45) before following Step 3's port math.
+
+This covers the UniFi OS setup on the UCG-Max: 4 VLANs, firewall
+policies, and port forwards. All of this is done through the UniFi web
+UI (or the UniFi mobile app) — there is no CLI scripting for this device
+in this kit, since Ubiquiti doesn't expose a stable local API/CLI for
+this scope of config without extra tooling. Follow this as a manual
+checklist.
+
+**This is a live, in-use home network** (AP mesh, all household devices)
+per this project's Strict Requirement 7 — the steps below are
+deliberately ordered to avoid touching anything already working
+(existing internet access, existing Wi-Fi/mesh) until the very last,
+lowest-risk step. Read through once before starting so you know where
+the safe stopping points are if you need to pause partway through.
 
 ## Initial Setup
 
-1. Connect the UCG-Fiber's WAN port to your ONT/fiber handoff.
-2. Connect a laptop to one of its LAN ports (or use the UniFi mobile app over
-   Bluetooth for first-time setup).
+1. Connect the UCG-Max's WAN port (the 2.5GbE RJ45 port labeled/default
+   as WAN) to your ONT/modem handoff.
+2. Connect a laptop to one of its LAN ports (or use the UniFi mobile app
+   over Bluetooth for first-time setup).
 3. Follow the guided setup wizard: create/log into your Ubiquiti account,
    name the site, let it detect the WAN connection.
 4. Confirm you're getting your real public IP on the WAN interface (Settings
    → Internet → WAN) — should match what `curl -s https://api.ipify.org`
    reports from a device behind it.
+
+**If this UCG-Max is already your live gateway** (as is the case here —
+it already has an AP mesh and household devices behind it), Initial
+Setup is already done. Skip straight to Step 1.
 
 ## Step 1: Create the 4 VLANs
 
@@ -27,17 +52,45 @@ ever want it).
 
 | Name | VLAN ID | Subnet | Purpose |
 |---|---|---|---|
-| Trusted-LAN | 10 | 192.168.10.0/24 | Your existing devices, PC, phones |
+| Trusted-LAN | 10 | **your existing subnet** (e.g. `192.168.68.0/22`) | Your existing devices, PC, phones, AP mesh |
 | Prod | 20 | 192.168.20.0/24 | dune-prod VM |
 | Dev | 21 | 192.168.21.0/24 | dune-dev VM |
 | Mgmt | 30 | 192.168.30.0/24 | Proxmox host, iDRAC |
 
-Note: if your existing LAN devices are already on a different subnet
-(e.g., the `192.168.68.0/22` seen on the current gaming PC), you can either
-renumber everything to match this table, or keep your existing Trusted-LAN
-subnet as-is and just add VLANs 20/21/30 as the new ones — the exact Trusted
-subnet doesn't matter, what matters is that Prod/Dev/Mgmt are separate
-VLANs from it and from each other.
+**Keep Trusted-LAN on whatever subnet your existing devices are already
+using** (e.g. `192.168.68.0/22`, seen on this network) rather than
+renumbering to match a fresh `192.168.10.0/24` — as long as it doesn't
+overlap Prod/Dev/Mgmt above (a `/22` at `.68.0` spans `.68.0`–`.71.255`,
+which doesn't), there's no reason to change it. Renumbering would force
+every existing device (mesh APs, phones, laptops — anything with a
+current DHCP lease or static reservation) to drop and renew on the new
+range, a brief but real disruption for the whole household with no
+actual benefit — the VLAN *ID* (10) and the fact that it's a distinct
+VLAN from Prod/Dev/Mgmt is what provides the isolation this design
+needs, not the specific subnet number.
+
+**This is unrelated to ongoing connectivity issues, if you have any.**
+If devices are dropping or reconnecting unpredictably independent of
+this migration, that's a separate problem (the most common cause in a
+mixed mesh+UniFi setup is the mesh still running its own DHCP server
+alongside the UCG-Max's — confirm the mesh is in bridge/access-point
+mode, not router mode, before assuming subnetting is the issue).
+Keeping the existing subnet here only avoids a migration-induced
+reconnect event; it does not fix or mask an unrelated stability
+problem.
+
+**Do this first, before touching any physical ports or cabling.** Creating
+these networks in the UniFi UI does not disrupt any existing traffic —
+it only becomes disruptive once you start reassigning ports in Step 3,
+so there's no risk yet at this stage.
+
+**If your AP mesh is third-party** (eero, Google Nest WiFi, TP-Link Deco,
+etc. — not UniFi access points), keep your existing Trusted-LAN subnet
+exactly as-is and do not touch the mesh's existing port or cable at any
+point in this guide. Most consumer mesh systems cannot accept an
+802.1Q VLAN trunk and expect a plain untagged connection; the new
+VLANs (Prod/Dev/Mgmt) are added alongside your existing network, not
+by modifying it.
 
 ## Step 2: Proxmox Bridge Configuration (DO THIS FIRST)
 
@@ -62,45 +115,97 @@ ifreload -a
 ignored and both VMs fall onto the same untagged broadcast domain —
 breaking the entire inter-VLAN security model with no visible symptom.**
 
-## Step 3: Assign the UCG-Fiber Port as a Trunk
+## Step 3: Assign the R740's Existing Port as a Trunk
 
-Use a single LAN port on the UCG-Fiber configured as a **trunk port**
-carrying all four VLANs tagged:
+**If the R740 is already physically cabled to the UCG-Max** (as is the
+case here), you are not running new cabling in this step — you're
+changing that one existing port's profile from whatever it currently
+is (likely a plain, untagged LAN port) to a tagged 802.1Q trunk. The
+cable itself doesn't move.
 
-- Pick one UCG-Fiber LAN port and set it to carry VLANs 10, 20, 21, 30
-  tagged (802.1Q trunk)
-- Connect the R740's vmbr0 physical port (eno1 or equivalent) to this
-  UCG-Fiber trunk port
-- The remaining three R740 NIC ports are free for future LACP bonding,
-  a dedicated management path, or a failover link
+**This is the first step in this guide that touches something already
+live.** It only affects the single port the R740 is connected to — your
+AP mesh's port, and every other device's port, are untouched by this
+step. If something goes wrong, the blast radius is limited to the R740
+losing network connectivity, not your whole household.
 
-**Important:** This is a trunk-port topology — one cable, multiple tagged
-VLANs. Do NOT configure three separate access ports. The VM NIC config
-uses `tag=20` and `tag=21` which emit 802.1Q-tagged frames. An access
-port would drop them.
+In the UniFi Network app, go to **Devices → [your UCG-Max] → Ports**,
+find the port the R740 is connected to, and set its **Port Profile**
+(sometimes labeled **Native Network / Tagged Networks** depending on
+UniFi Network version) to:
 
-## Step 3: Firewall Rules — Inter-VLAN Isolation
+- **Native/Untagged Network**: leave unset, or set to none — this port
+  should carry no untagged traffic
+- **Tagged Networks**: select all four — Trusted-LAN (10), Prod (20),
+  Dev (21), Mgmt (30)
 
-By default, UniFi allows all VLANs to talk to each other freely. You want
-to lock this down. Go to **Settings → Firewall & Security → Create New
-Rule** and add these, in this order (rules are evaluated top-down, first
-match wins):
+This makes the port an 802.1Q trunk carrying all four VLANs tagged.
+Do NOT split this into three separate access ports even if you have
+spare ports available — the VM NIC config on the Proxmox side uses
+`tag=20` and `tag=21`, which emit 802.1Q-tagged frames; a plain access
+port silently drops them, and the failure looks like "the VM has no
+network" with no obvious cause.
 
-1. **Allow: Trusted-LAN → Mgmt** (so you can reach the Proxmox web UI and
-   iDRAC from your normal devices)
-2. **Allow: Trusted-LAN → Prod, Trusted-LAN → Dev** (so you can reach the
-   consoles via VPN/local access — see Step 5)
-3. **Block: Dev → Prod** (Dev should never be able to reach Prod directly —
-   this is the blast-radius containment discussed earlier)
-4. **Block: Prod → Dev** (same, other direction)
-5. **Block: Prod → Mgmt, Dev → Mgmt** (neither battlegroup VM should be able
-   to reach the Proxmox hypervisor or iDRAC — if a VM is ever compromised,
-   this stops it from pivoting to the hypervisor layer)
-6. **Allow: established/related** (standard stateful return-traffic rule —
-   UniFi usually has this by default, confirm it exists)
-7. **Default deny** for everything else not explicitly allowed above
+**Verify immediately after applying:** confirm the R740/Proxmox host
+still has network connectivity (ping it from another device, or check
+the physical link light). If it drops, revert the port profile change
+and re-check the VLAN IDs before retrying — this is expected to be a
+one-command-away fix, not something to troubleshoot for hours.
 
-## Step 4: WAN Port Forwards (Prod ONLY)
+## Step 4: Firewall Policies — Inter-VLAN Isolation
+
+**UniFi Network 9.0+ uses zone-based firewalling**, not a flat ordered
+list of Allow/Block rules. If your UniFi Network app still shows the
+older rule-list UI, migrate first: **Security → Traffic & Firewall
+Rules → Upgrade** (Ubiquiti's own migration tool — takes seconds, no
+downtime, and produces functionally identical rules before you add
+anything new). If you already see **Security → Zones** or a **Zone
+Matrix**, you're already on the new model — skip the migration step.
+
+By default, every new network you created in Step 1 is placed in the
+built-in **Internal** zone, and Internal→Internal traffic is
+**Allow All** — this is exactly why Prod/Dev/Mgmt can currently reach
+each other and your Trusted-LAN devices freely, and why this step
+exists.
+
+**Recommended approach:** create three custom zones (e.g. `Prod-Zone`,
+`Dev-Zone`, `Mgmt-Zone`) and move the Prod, Dev, and Mgmt networks into
+them respectively (a network can only belong to one zone at a time,
+set when editing the network or in the Firewall/Zones section). Leave
+Trusted-LAN in the default **Internal** zone. Then, in the **Zone
+Matrix** (**Settings → Zones** or **Settings → Policy Table**,
+depending on your UniFi Network version), configure:
+
+1. **Internal → Mgmt-Zone: Allow** (so you can reach the Proxmox web UI
+   and iDRAC from your normal devices)
+2. **Internal → Prod-Zone: Allow, Internal → Dev-Zone: Allow** (so you
+   can reach the consoles via VPN/local access — see Step 6)
+3. **Dev-Zone → Prod-Zone: Block** (Dev should never reach Prod
+   directly — this is the blast-radius containment discussed earlier)
+4. **Prod-Zone → Dev-Zone: Block** (same, other direction)
+5. **Prod-Zone → Mgmt-Zone: Block, Dev-Zone → Mgmt-Zone: Block**
+   (neither battlegroup VM should be able to reach the Proxmox
+   hypervisor or iDRAC — if a VM is ever compromised, this stops it
+   from pivoting to the hypervisor layer)
+6. Leave every zone pair not listed above at its **default** value —
+   do not manually add a blanket "default deny" policy on top of the
+   zone matrix; the built-in per-zone defaults (e.g. External→Internal
+   already defaults to block-except-return-traffic) already provide
+   this, and adding a conflicting custom rule can produce confusing,
+   hard-to-debug interactions with the built-in policies.
+
+**Double-check both directions for every rule.** Per Ubiquiti's own
+documentation, blocking Zone A → Zone B does not automatically block
+Zone B → Zone A — you must configure both directions explicitly, which
+is why rules 3/4 and the two halves of rule 5 are listed as separate
+entries above.
+
+**Do not block traffic to the built-in Gateway zone** for any of your
+new zones — this handles DHCP/DNS/management traffic for the UCG-Max
+itself, and blocking it can break basic network function in
+hard-to-diagnose ways.
+
+## Step 5: WAN Port Forwards (Prod ONLY)
 
 Go to **Settings → Firewall & Security → Port Forwarding → Create New
 Port Forward**. Add these three rules, all pointing at **dune-prod's VM IP**
@@ -113,7 +218,7 @@ Port Forward**. Add these three rules, all pointing at **dune-prod's VM IP**
 | Dune RMQ HTTP | 31983 | 192.168.20.10 | 31983 | TCP |
 
 **Do NOT create a port forward for 8088 (admin console) on either VM.**
-This is intentional — the admin console is reached via VPN only (Step 5),
+This is intentional — the admin console is reached via VPN only (Step 6),
 never directly from the internet. This directly closes the CRIT-01-class
 exposure identified earlier in this project (the live gaming-PC setup
 currently has `console.darkdante.org` pointed at the console over a
@@ -124,7 +229,7 @@ here without at least Cloudflare Access in front of it, see
 **Dev gets no port forwards at all** — per the original Phase 0 decision,
 Dev is LAN/VPN-only, no public testers.
 
-## Step 5: VPN Access for Remote Admin
+## Step 6: VPN Access for Remote Admin
 
 Go to **Settings → VPN → Teleport** (Ubiquiti's zero-config WireGuard VPN)
 or **Settings → VPN → WireGuard** (manual config) and set up a VPN profile
@@ -136,12 +241,21 @@ through the tunnel.
 This is how you'll reach both consoles remotely without ever exposing them
 directly to the WAN.
 
-## Step 6: Verify Throughput Before Moving On
+## Step 7: Verify Throughput and Existing Devices Before Moving On
 
-From a device on the Trusted-LAN VLAN, run a speed test (fast.com or
-speedtest.net) and confirm you're seeing close to your full 2Gbps — this
-validates the UCG-Fiber isn't bottlenecking your fiber line, which was the
-whole reason you replaced the Deco mesh unit for this role.
+1. From a device on the Trusted-LAN VLAN, run a speed test (fast.com or
+   speedtest.net) and confirm you're seeing close to your full ISP
+   throughput — this validates the UCG-Max isn't bottlenecking your
+   connection.
+2. **Confirm your AP mesh and all household devices still have working
+   internet/Wi-Fi.** Since the mesh's port was never touched in this
+   guide, this should already be the case — but verify explicitly
+   rather than assume, given everything else on this network was live
+   throughout this change.
+3. Confirm the R740/Proxmox host still has connectivity after the
+   Step 3 trunk-port change (re-check if you skipped the inline
+   verification in that step).
 
-Once VLANs, firewall rules, and port forwards are in place and verified,
-move to `scripts/01-validate-avx2.sh` on the Proxmox side.
+Once VLANs, firewall policies, port forwards, and the trunk port are in
+place and verified — and your existing devices/mesh are confirmed
+unaffected — move to `scripts/01-validate-avx2.sh` on the Proxmox side.

--- a/docs/04-post-standup-hardening.md
+++ b/docs/04-post-standup-hardening.md
@@ -29,8 +29,8 @@ On each VM:
 grep ADMIN_BIND_HOST .env
 ```
 Should be `127.0.0.1` or a private VLAN IP, never `0.0.0.0` exposed with a
-WAN port-forward pointed at it. Cross-check against your UCG-Fiber port
-forward list (`docs/02-network-setup.md` Step 4) — there should be **no**
+WAN port-forward pointed at it. Cross-check against your UCG-Max port
+forward list (`docs/02-network-setup.md` Step 5) — there should be **no**
 forward rule for port 8088 on either VM, period.
 
 ## 3. Cloudflare Tunnel / Access for remote console access
@@ -51,7 +51,7 @@ had no additional access gate in front of it (bare hostname → :8088). Add
    independent layer, not a replacement for the console's own auth
 
 Alternatively, skip the public hostname entirely and only reach the console
-via the UniFi Teleport/WireGuard VPN set up in `02-network-setup.md` Step 5
+via the UniFi Teleport/WireGuard VPN set up in `02-network-setup.md` Step 6
 — simpler, one less moving part, and arguably better given the console
 mounts the Docker socket (see item 5 below).
 
@@ -95,15 +95,15 @@ From the `dune-dev` VM, try to reach `dune-prod`'s IP and vice versa:
 ping -c 3 <dune-prod-ip>      # should fail/timeout
 curl -m 5 http://<dune-prod-ip>:8088   # should fail/timeout
 ```
-If either succeeds, go back to `02-network-setup.md` Step 3 and fix the
-inter-VLAN block rules before going further — this is the isolation that
-contains blast radius if one VM is ever compromised.
+If either succeeds, go back to `02-network-setup.md` Step 4 and fix the
+inter-VLAN firewall zone policies before going further — this is the
+isolation that contains blast radius if one VM is ever compromised.
 
 ## 8. Confirm iDRAC/Proxmox management plane has no WAN route
 
 From outside your network entirely (phone on cellular), confirm you
 **cannot** reach the Proxmox web UI or iDRAC directly — only via the VPN set
-up in `02-network-setup.md` Step 5. This is your hypervisor-level admin
+up in `02-network-setup.md` Step 6. This is your hypervisor-level admin
 plane; it should never be internet-facing under any circumstance.
 
 ## 9. Rotate the Funcom tokens' file permissions


### PR DESCRIPTION
## Risk classification: Low (documentation only) — but governs a live-system change

This PR only changes documentation (`docs/02-network-setup.md`,
`docs/04-post-standup-hardening.md`). No code, no CI/deploy impact.
However, this doc is the walkthrough for configuring a **live,
currently-in-use home network** (UCG-Max with a third-party AP mesh
and all household devices behind it) — accuracy here directly affects
a real change the user will execute by hand on live equipment.

## Summary

Closes #31.

- **Device name corrected**: UCG-Fiber -> UCG-Max throughout this file.
  Confirmed via Ubiquiti's own tech-specs page
  (techspecs.ui.com/unifi/cloud-gateways/ucg-max) — different hardware,
  different port count/throughput than what the doc previously assumed.
- **Fixed a duplicate '## Step 3' heading** left over from an earlier,
  not-yet-merged revision on `fix/ci-audit-fixes` (this PR's base
  content for this file was cherry-picked from that branch since it
  already had a better trunk-port design than `main`'s stale
  3-access-port version — see first commit in this PR for details).
- **Step 3 (trunk port)** rewritten: the R740 is already physically
  cabled to the UCG-Max, so this is a port-profile reassignment, not
  new wiring. Updated to current UniFi terminology (Native/Tagged
  Networks) and added inline connectivity verification.
- **Step 4 (firewall)** rewritten from a flat ordered Allow/Block rule
  list to UniFi Network 9.0+'s actual **zone-based firewall** model —
  confirmed via Ubiquiti's own current docs ('Migrating to Zone-Based
  Firewalls in UniFi', 'Zone-Based Firewalls in UniFi'). The old
  simple-rule UI doesn't reflect current UniFi Network versions.
- **Step 1 subnet guidance** updated to keep the network's actual
  existing subnet (`192.168.68.0/22`) rather than defaulting to a
  fresh `192.168.10.0/24` — avoids forcing every existing device
  (mesh APs, phones, laptops) to drop and renew DHCP leases during
  migration. Explicitly scoped: this avoids a migration-induced
  reconnect, it is not a fix for any unrelated connectivity-stability
  issue.
- **Third-party mesh guidance added**: the mesh's existing port/cable
  is never touched anywhere in this guide (most consumer mesh systems
  can't accept an 802.1Q trunk).
- **Minimal-disruption step ordering/verification** added throughout,
  since this is a live home network per Strict Requirement 7.
- Renumbered Steps 4/5/6 -> 5/6/7 (new firewall-zones step inserted at
  4) and fixed all 4 cross-references in `04-post-standup-hardening.md`
  that pointed at the old step numbers.

## Verification
- `gitleaks detect` clean on both changed files.
- No broken `docs/` relative markdown links introduced (checked
  against this repo's own CI link-check pattern).
- All `02-network-setup.md` step-number cross-references repo-wide
  re-checked via `grep` and confirmed consistent after renumbering.

## Documentation impact
This PR is the documentation fix. No other doc needed updating beyond
the 4 cross-reference line fixes in `04-post-standup-hardening.md`
already included here.

## Not addressed in this PR
Issue #32 (the same UCG-Fiber -> UCG-Max rename across 6 other files:
README.md, 00-START-HERE.md, 01-proxmox-install.md,
03-runbook-day-of.md, PROMPT-00/01) is deliberately deferred — lower
urgency, no live-system risk, kept separate to avoid scope creep in
this PR.

Closes #31