### PR TITLE
ci: grant pull-requests:read so gitleaks-action can comment on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   shellcheck:


### PR DESCRIPTION
## Risk classification: Low

Single-line permissions addition to a GitHub Actions workflow. No application code, no runtime behavior change for the actual deployment kit -- purely a CI-token-scope fix.

## Summary

Closes #34.

`gitleaks/gitleaks-action@v2` calls `GET /repos/.../pulls/{n}/commits` on `pull_request`-triggered runs, to scope its PR-comment output to the right commit range. This requires `pull-requests: read` on the workflow's `GITHUB_TOKEN`. The workflow's `permissions:` block only granted `contents: read`, causing a **reproducible** `403: Resource not accessible by integration` on the `gitleaks` job -- confirmed by re-running the identical failed job twice (`gh run rerun --failed`) and observing the same error both times, ruling out a one-off flake.

This was blocking `ci-gate` (which requires all jobs including `gitleaks` to succeed) on PR pushes -- found while opening an unrelated documentation PR (#33) that hit this exact failure.

## Verification

The gitleaks scan itself always completed successfully in every observed run (`no leaks found`) -- only the post-scan PR-comment API call failed. This PR's own CI run against this change will serve as the live verification that the fix works.

## Documentation impact

None -- this is a CI-infrastructure-only change with no user-facing or operator-facing behavior.

Closes #34