### PR TITLE
docs: record Step 3 (trunk port) completion and verification

### DIFF
--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -26,14 +26,20 @@ deliberately ordered to avoid touching anything already working
 lowest-risk step. Read through once before starting so you know where
 the safe stopping points are if you need to pause partway through.
 
-**Status on this deployment (2026-08-11):** Step 1 (VLAN creation) has
-been completed and independently verified via the UniFi Integration
-API — Prod, Dev, and Mgmt networks exist on the live gateway. The
+**Status on this deployment (2026-08-12):** Steps 1 and 3 are complete
+and independently verified. Step 1: Prod, Dev, and Mgmt networks exist
+on the live gateway (confirmed via the UniFi Integration API); the
 existing Default/Trusted-LAN network was confirmed already correctly
-configured and was left untouched. Step 3's target port was identified
-(port 3 on the UCG-Max, confirmed via live port-state change when the
-R740's data NIC was connected) but the trunk-port profile itself had
-not yet been applied as of this note. Steps 4 onward not yet started.
+configured and was left untouched. Step 3: port 3 on the UCG-Max
+(identified via a live port-state change when the R740's data NIC was
+connected) was configured as a trunk via the UniFi web UI and verified
+via the legacy internal API — `forward: customize`,
+`tagged_vlan_mgmt: custom`, `native_networkconf_id: ""` (no
+native/untagged network, as intended). Port 2 (iDRAC) was independently
+confirmed unchanged (`forward: all`, no `tagged_vlan_mgmt` field) to
+rule out any accidental cross-port effect. Port 3's physical link
+remained UP throughout at the same speed, confirming the VLAN change
+didn't disrupt the physical link layer. Steps 4 onward not yet started.
 
 ## Initial Setup
 


### PR DESCRIPTION
## Risk classification: Low (documentation only, records completed live-system change)

## Summary

Follow-up to #37 -- records that Step 3 (trunk-porting the R740's UCG-Max port) has now been completed and independently verified, continuing the same live-execution status tracking established in that PR.

Port 3 was configured as an 802.1Q trunk via the UniFi web UI (chosen over attempting the write via the undocumented legacy internal API, after confirming the official Integration API returns `405 Method Not Allowed` for port-profile writes -- this is a real gap in the official API's current write coverage, not something worth working around with an unofficial endpoint for a live-network change).

## Verification performed
- Legacy internal `stat/device` endpoint (read-only) confirms port 3 now shows `forward: customize`, `tagged_vlan_mgmt: custom`, `native_networkconf_id: ""` (no native/untagged network) -- exactly the trunk configuration intended.
- Port 2 (iDRAC) independently re-checked and confirmed **completely unchanged** (`forward: all`, no `tagged_vlan_mgmt` field at all) -- rules out any accidental cross-port effect from the UI change.
- Port 3's physical link state remained `UP` at the same 1000 Mbps speed before and after the change, confirming the VLAN/trunk reconfiguration didn't disrupt the physical link layer.

## Documentation impact
This PR is the documentation update.

No new issue filed for this specific change -- it's a progress-tracking update to the same live-execution status note introduced in #37, not a new defect or gap.