### PR TITLE
docs: record Step 4 (firewall zones and policies) completion and verification

### DIFF
--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -26,20 +26,42 @@ deliberately ordered to avoid touching anything already working
 lowest-risk step. Read through once before starting so you know where
 the safe stopping points are if you need to pause partway through.
 
-**Status on this deployment (2026-08-12):** Steps 1 and 3 are complete
-and independently verified. Step 1: Prod, Dev, and Mgmt networks exist
-on the live gateway (confirmed via the UniFi Integration API); the
-existing Default/Trusted-LAN network was confirmed already correctly
-configured and was left untouched. Step 3: port 3 on the UCG-Max
-(identified via a live port-state change when the R740's data NIC was
-connected) was configured as a trunk via the UniFi web UI and verified
-via the legacy internal API — `forward: customize`,
-`tagged_vlan_mgmt: custom`, `native_networkconf_id: ""` (no
-native/untagged network, as intended). Port 2 (iDRAC) was independently
-confirmed unchanged (`forward: all`, no `tagged_vlan_mgmt` field) to
-rule out any accidental cross-port effect. Port 3's physical link
-remained UP throughout at the same speed, confirming the VLAN change
-didn't disrupt the physical link layer. Steps 4 onward not yet started.
+**Status on this deployment (2026-08-12):** Steps 1, 3, and 4 are
+complete and independently verified.
+
+Step 1: Prod, Dev, and Mgmt networks exist on the live gateway
+(confirmed via the UniFi Integration API); the existing
+Default/Trusted-LAN network was confirmed already correctly configured
+and was left untouched.
+
+Step 3: port 3 on the UCG-Max (identified via a live port-state change
+when the R740's data NIC was connected) was configured as a trunk via
+the UniFi web UI and verified via the legacy internal API —
+`forward: customize`, `tagged_vlan_mgmt: custom`,
+`native_networkconf_id: ""` (no native/untagged network, as intended).
+Port 2 (iDRAC) was independently confirmed unchanged (`forward: all`,
+no `tagged_vlan_mgmt` field) to rule out any accidental cross-port
+effect. Port 3's physical link remained UP throughout at the same
+speed, confirming the VLAN change didn't disrupt the physical link
+layer.
+
+Step 4: this gateway was running UniFi Network 10.5.67 but had **not**
+yet migrated to zone-based firewalling (confirmed via the Integration
+API returning `"Zone Based Firewall is not configured"` on the
+firewall/zones and firewall/policies endpoints, despite the app
+version being well past the 9.0.108 release that introduced it) — the
+one-click **Security → Traffic & Firewall Rules → Upgrade** migration
+was run first via the web UI. Three custom zones were then created via
+the API (Prod-Zone, Dev-Zone, Mgmt-Zone), each containing exactly its
+corresponding network, moving them out of the built-in Internal zone
+which now correctly contains only the Default/Trusted-LAN network. All
+7 directional policies from the table below were created and verified
+present with the correct source zone, destination zone, and action via
+a follow-up GET request (not just trusted from the POST response) —
+paginate past the default 25-result page limit if checking manually,
+since the migration itself auto-generates ~20 built-in per-zone
+policies that push custom ones past the first page. Steps 5 onward not
+yet started.
 
 ## Initial Setup
 


### PR DESCRIPTION
## Risk classification: Low (documentation only, records completed live-system change)

## Summary

Follow-up to #38 -- records that Step 4 (firewall zone-based isolation between Prod/Dev/Mgmt/Trusted-LAN) has been completed and independently verified on the live UCG-Max.

## What was discovered and done
- This gateway (UniFi Network 10.5.67) had **not** migrated to zone-based firewalling despite being well past the 9.0.108 release that introduced it -- confirmed via the Integration API returning `"Zone Based Firewall is not configured"` on the relevant endpoints.
- Ran Ubiquiti's own one-click migration (**Security → Traffic & Firewall Rules → Upgrade**) via the web UI -- no API endpoint exists to trigger this, confirmed by testing.
- Post-migration, all 4 project networks landed in the built-in **Internal** zone by default (matches Ubiquiti's own documented migration behavior).
- Created 3 custom zones via the API (`Prod-Zone`, `Dev-Zone`, `Mgmt-Zone`) and moved Prod/Dev/Mgmt into them, leaving Internal correctly containing only Default/Trusted-LAN.
- Created and independently verified all 7 directional firewall policies (3 Allow from Internal, 4 Block between Prod/Dev/Mgmt) via the API.

## Verification performed
- Every zone and policy creation was verified via a follow-up GET, not just trusted from the POST response.
- **Caught and worked around a pagination gotcha**: the policies endpoint defaults to a 25-result page limit, and the zone migration itself auto-generates ~20 built-in per-zone policies -- an unpaginated check would have shown only 3 of 7 custom policies and incorrectly suggested 4 were missing. Re-queried with `limit=200` and confirmed all 7 present with correct source zone, destination zone, and action.

## Documentation impact
This PR is the documentation update, continuing the live-execution status tracking established in #37/#38.

No new issue filed -- progress-tracking update to the existing live-execution status note, not a new defect.

## Remaining work (not in this PR)
- Step 5: WAN port forwards (Prod only)
- Step 6: VPN access for remote admin
- Step 7: final throughput/connectivity verification