### PR TITLE
docs: record Step 5 partial completion (added missing 31983 forward)

### DIFF
--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -62,29 +62,34 @@ paginate past the default 25-result page limit if checking manually,
 since the migration itself auto-generates ~20 built-in per-zone
 policies that push custom ones past the first page.
 
-Step 5 (partial): discovered **two pre-existing WAN port forwards**
-(`DA-UDP` 7777-7810/UDP, `DA-TCP` 31982/TCP) already configured,
-pointing at `192.168.68.92` — a device on the old flat Trusted-LAN,
-almost certainly left over from before this VLAN migration. **These
-two were deliberately left untouched**, since that device may still be
-an actively-serving game server and modifying/removing its forwards
-without first confirming its current status would risk disrupting
-real, in-progress player sessions — consistent with this project's
-rule to never touch a live system without confirming status first.
-Only the missing third forward was added: `DA-RMQ-HTTP` (31983/TCP) ->
-`192.168.20.10:31983`, confirmed required (not internal-only) per the
+Step 5 (deferred until Prod VM exists): discovered two pre-existing
+WAN port forwards (originally named `DA-UDP` 7777-7810/UDP and
+`DA-TCP` 31982/TCP) already configured, pointing at `192.168.68.92`.
+**Confirmed by the operator: `192.168.68.92` is the actual, currently
+active game server** — not a stale leftover. A third forward was
+briefly added pointing at the future Prod VLAN IP (`192.168.20.10`,
+port 31983/TCP), but this was premature since nothing is listening
+there yet (Proxmox/the Prod VM don't exist yet) — the operator
+correctly removed it and instead consolidated all three required ports
+(7777-7810/UDP, 31982/TCP, 31983/TCP) onto the two existing rules,
+renamed to `DA-Game Server` and `DA-RMQ` respectively, both still
+correctly pointing at `192.168.68.92` where the game server actually
+runs today. 31983 was confirmed required (not internal-only) per the
 upstream Core project's own setup script (`runtime/scripts/init.sh`'s
 "Public hosting reminder" explicitly lists TCP 31983 alongside 31982
 and the UDP game range) and its server-gateway container
 (`runtime/scripts/start-server-gateway.sh`), which advertises this
 port bound to the public `SERVER_IP` directly to Funcom's live
-services — it is a genuinely public-facing port, not confined to
-internal container-to-container traffic. This new forward is purely
-additive and does not affect the two existing, possibly-live forwards.
-**The two stale forwards still need to be updated or replaced to point
-at `192.168.20.10` once `192.168.68.92`'s current status is confirmed**
-— tracked as follow-up work, not done in this pass. Steps 6 onward not
-yet started.
+services.
+
+**The actual cutover — repointing these forwards from `192.168.68.92`
+to the new Prod VLAN IP — must happen as a deliberate, coordinated step
+during the real migration window**, not before: only do this once the
+new dune-prod VM exists, is running the game server, and a live
+cutover has been planned (ideally with no active players, or an
+announced maintenance window) — repointing a live game server's
+forwards while players are connected would disconnect them mid-session
+with no warning. Steps 6 onward not yet started.
 
 ## Initial Setup
 
@@ -278,32 +283,38 @@ hard-to-diagnose ways.
 
 ## Step 5: WAN Port Forwards (Prod ONLY)
 
-**Check for pre-existing forwards from a previous non-VLAN setup
-before creating anything new.** If this gateway has ever hosted a game
-server before this migration, port forwards for the game/RMQ ports may
-already exist, pointing at whatever IP that previous setup used (e.g.
-a device still on the old flat Trusted-LAN subnet) rather than the new
-Prod VLAN IP. **Do not blindly delete or edit an existing forward
-without first confirming the device it currently points at isn't an
-actively-serving game server** — if it might still have players
-connected, treat it exactly like any other live system per this
-project's rules: confirm status before touching it. It's always safe
-to *add* a new, correctly-targeted forward alongside a stale one
-(purely additive, doesn't affect existing traffic); reconciling/
-removing the stale entry can wait until the old device is confirmed
-safe to retire.
+**This step is a cutover, not an additive setup step — do it last, and
+only when dune-prod is actually ready to take over.** If this gateway
+already has an active game server running on the old flat Trusted-LAN
+(true for this deployment: forwards already exist pointing at a
+currently-live game server), do NOT create a second, parallel set of
+forwards pointing at the new Prod VLAN IP ahead of time — nothing is
+listening there until the new dune-prod VM exists and is actually
+running the game server, so an early forward is dead weight at best,
+and repointing the *existing* forwards early would disconnect real
+players with no warning.
 
-**All three ports below are required, including 31983** — this is not
-an internal-only port that can be skipped. Confirmed via the upstream
+**All three ports are required, including 31983** — this is not an
+internal-only port that can be skipped. Confirmed via the upstream
 Core project's own setup wizard (`runtime/scripts/init.sh`'s "Public
 hosting reminder" lists TCP 31983 alongside 31982 and the UDP game
 range) and its server-gateway container, which advertises this port
 bound to the public server IP directly to Funcom's live services as
 part of the standard player-connection path.
 
-Go to **Settings → Firewall & Security → Port Forwarding → Create New
-Port Forward**. Add these three rules, all pointing at **dune-prod's VM IP**
-(e.g., `192.168.20.10` — pick and note down a static IP for it):
+**When dune-prod is actually ready** (game server running, tested,
+ready to take live traffic), do the cutover as a single deliberate
+step, ideally during a maintenance window with players warned in
+advance or with none currently connected: update the *existing*
+forward rules' target IP from the old device to `192.168.20.10` (pick
+and note down a static IP for dune-prod's VM). Editing the existing
+rules in place (rather than deleting and recreating) preserves
+whatever WAN-side dependent config (DNS, monitoring, firewall logging
+history) already references those rule IDs.
+
+Go to **Settings → Firewall & Security → Port Forwarding**, and update
+(or, on a fresh setup with no pre-existing rules, create) these three
+rules to point at **dune-prod's VM IP**:
 
 | Name | WAN Port(s) | Forward IP | Forward Port(s) | Protocol |
 |---|---|---|---|---|

--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -60,7 +60,30 @@ present with the correct source zone, destination zone, and action via
 a follow-up GET request (not just trusted from the POST response) —
 paginate past the default 25-result page limit if checking manually,
 since the migration itself auto-generates ~20 built-in per-zone
-policies that push custom ones past the first page. Steps 5 onward not
+policies that push custom ones past the first page.
+
+Step 5 (partial): discovered **two pre-existing WAN port forwards**
+(`DA-UDP` 7777-7810/UDP, `DA-TCP` 31982/TCP) already configured,
+pointing at `192.168.68.92` — a device on the old flat Trusted-LAN,
+almost certainly left over from before this VLAN migration. **These
+two were deliberately left untouched**, since that device may still be
+an actively-serving game server and modifying/removing its forwards
+without first confirming its current status would risk disrupting
+real, in-progress player sessions — consistent with this project's
+rule to never touch a live system without confirming status first.
+Only the missing third forward was added: `DA-RMQ-HTTP` (31983/TCP) ->
+`192.168.20.10:31983`, confirmed required (not internal-only) per the
+upstream Core project's own setup script (`runtime/scripts/init.sh`'s
+"Public hosting reminder" explicitly lists TCP 31983 alongside 31982
+and the UDP game range) and its server-gateway container
+(`runtime/scripts/start-server-gateway.sh`), which advertises this
+port bound to the public `SERVER_IP` directly to Funcom's live
+services — it is a genuinely public-facing port, not confined to
+internal container-to-container traffic. This new forward is purely
+additive and does not affect the two existing, possibly-live forwards.
+**The two stale forwards still need to be updated or replaced to point
+at `192.168.20.10` once `192.168.68.92`'s current status is confirmed**
+— tracked as follow-up work, not done in this pass. Steps 6 onward not
 yet started.
 
 ## Initial Setup
@@ -254,6 +277,29 @@ itself, and blocking it can break basic network function in
 hard-to-diagnose ways.
 
 ## Step 5: WAN Port Forwards (Prod ONLY)
+
+**Check for pre-existing forwards from a previous non-VLAN setup
+before creating anything new.** If this gateway has ever hosted a game
+server before this migration, port forwards for the game/RMQ ports may
+already exist, pointing at whatever IP that previous setup used (e.g.
+a device still on the old flat Trusted-LAN subnet) rather than the new
+Prod VLAN IP. **Do not blindly delete or edit an existing forward
+without first confirming the device it currently points at isn't an
+actively-serving game server** — if it might still have players
+connected, treat it exactly like any other live system per this
+project's rules: confirm status before touching it. It's always safe
+to *add* a new, correctly-targeted forward alongside a stale one
+(purely additive, doesn't affect existing traffic); reconciling/
+removing the stale entry can wait until the old device is confirmed
+safe to retire.
+
+**All three ports below are required, including 31983** — this is not
+an internal-only port that can be skipped. Confirmed via the upstream
+Core project's own setup wizard (`runtime/scripts/init.sh`'s "Public
+hosting reminder" lists TCP 31983 alongside 31982 and the UDP game
+range) and its server-gateway container, which advertises this port
+bound to the public server IP directly to Funcom's live services as
+part of the standard player-connection path.
 
 Go to **Settings → Firewall & Security → Port Forwarding → Create New
 Port Forward**. Add these three rules, all pointing at **dune-prod's VM IP**


### PR DESCRIPTION
## Risk classification: Low (documentation only; the underlying infra state is now correctly aligned with reality)

## Summary

Closes #40's original framing (now retitled/refocused as a planned cutover task, not a bug). Continues the live-execution status tracking from #37/#38/#39.

## What actually happened (corrected after operator feedback)
- Found 2 pre-existing WAN port forwards (`DA-UDP` 7777-7810/UDP, `DA-TCP` 31982/TCP) pointing at `192.168.68.92`.
- **Initially assumed stale** (leftover from before this migration) and added a third forward pointing at the future Prod VLAN IP (`192.168.20.10`, 31983/TCP) alongside them.
- **Operator confirmed `192.168.68.92` is the actual, currently active game server** -- not stale. The `192.168.20.10` forward was premature (nothing listens there yet) and has been removed.
- All 3 required ports (7777-7810/UDP, 31982/TCP, 31983/TCP) are now consolidated onto the 2 existing forward rules (renamed `DA-Game Server` / `DA-RMQ`), still correctly pointing at `192.168.68.92`.

## Documentation changes
Step 5 rewritten to correctly describe the real cutover sequencing: repointing these forwards from `192.168.68.92` to the new Prod VLAN IP is a deliberate, coordinated step to be done last, once dune-prod's VM actually exists and is running the game server -- not something to do ahead of time or silently, since it will disconnect any currently-connected players the moment it happens.

## Verification
- `gitleaks` clean.
- Live gateway state re-checked via GET after the operator's changes, confirming exactly 2 forward rules exist, both still targeting `192.168.68.92`, with all 3 required ports covered between them.

## Remaining work (tracked in #40, retitled)
The actual cutover -- repointing these 2 forwards to `192.168.20.10` -- during a coordinated maintenance window once dune-prod exists.