### PR TITLE
docs: repo-wide UCG-Fiber -> UCG-Max rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This kit is built around:
 - **[dune-awakening-selfhost-docker](https://github.com/yacketrj/dune-awakening-selfhost-docker)**
   — the Docker-based self-host console/orchestrator for Dune: Awakening
   dedicated servers
-- A UniFi-based router/firewall (e.g. Ubiquiti UCG-Fiber or similar) for
+- A UniFi-based router/firewall (e.g. Ubiquiti UCG-Max or similar) for
   VLAN segmentation, firewall isolation between environments, and WAN port
   forwarding
 

--- a/docs/00-START-HERE.md
+++ b/docs/00-START-HERE.md
@@ -20,19 +20,19 @@ Dell R740 (Proxmox VE hypervisor)
 └── (ACP Discord bot stays on the OCI VPS — out of scope, do not touch)
 ```
 
-Network: UCG-Fiber router, 4 VLANs (Trusted / Prod / Dev / Management),
+Network: UCG-Max router, 4 VLANs (Trusted / Prod / Dev / Management),
 only Prod's game ports are forwarded to the internet. Admin consoles (port
 8088) are never exposed to WAN on either VM.
 
 ## Prerequisites Checklist (do these BEFORE 7/30)
 
-- [ ] UCG-Fiber router arrived, physically installed, basic setup done
+- [ ] UCG-Max router arrived, physically installed, basic setup done
 - [ ] Proxmox VE install USB prepared (see `01-proxmox-install.md`)
 - [ ] 2 new Funcom Self-Host Service Tokens generated (one per account, for
       Prod and Dev respectively) — save both strings in a password manager
 - [ ] GitHub OAuth token on the OCI ACP box rotated (separate from this
       project, but do this before 7/30 so it's off your plate)
-- [ ] R740 racked, powered, network cabled to the UCG-Fiber's LAN ports
+- [ ] R740 racked, powered, network cabled to the UCG-Max's LAN ports
 
 ## Directory Map
 
@@ -41,7 +41,7 @@ r740-deployment/
 ├── docs/
 │   ├── 00-START-HERE.md              <- you are here
 │   ├── 01-proxmox-install.md         <- hypervisor install (manual, BIOS-level)
-│   ├── 02-network-setup.md           <- UCG-Fiber VLAN/firewall config (manual, UI-based)
+│   ├── 02-network-setup.md           <- UCG-Max VLAN/firewall config (manual, UI-based)
 │   ├── 03-runbook-day-of.md          <- the actual 7/30 sequence, step by step
 │   └── 04-post-standup-hardening.md  <- security checklist after both VMs are live
 └── scripts/
@@ -57,7 +57,7 @@ r740-deployment/
 ## Order of Operations
 
 1. Read `01-proxmox-install.md`, install Proxmox on the R740.
-2. Read `02-network-setup.md`, configure the UCG-Fiber's VLANs and firewall
+2. Read `02-network-setup.md`, configure the UCG-Max's VLANs and firewall
    rules (do this in parallel with #1 if you have two people, or before/after —
    order between these two doesn't matter, both must be done before VM traffic
    needs to flow).

--- a/docs/01-proxmox-install.md
+++ b/docs/01-proxmox-install.md
@@ -80,7 +80,7 @@ select the USB device.
    manager — this is the master credential for the whole hypervisor
 6. **Network configuration**: this is your Proxmox **management** interface,
    which should land on VLAN 30 (Management) per the network design. If your
-   switch/UCG-Fiber isn't VLAN-configured yet at this point, just use a
+   switch/UCG-Max isn't VLAN-configured yet at this point, just use a
    temporary IP on your regular LAN for now — you can move it to the
    management VLAN after `02-network-setup.md` is done.
 7. Confirm and let it install (~10 minutes), then reboot.

--- a/docs/03-runbook-day-of.md
+++ b/docs/03-runbook-day-of.md
@@ -4,7 +4,7 @@ Print this or keep it open on a second device. Check off each step.
 
 ## Morning
 
-- [ ] Confirm UCG-Fiber VLANs/firewall/port-forwards from
+- [ ] Confirm UCG-Max VLANs/firewall/port-forwards from
       `02-network-setup.md` are all in place and verified (should already
       be done by now if you followed the pre-work checklist)
 - [ ] Confirm Proxmox VE is installed and reachable at its management IP
@@ -54,7 +54,7 @@ Print this or keep it open on a second device. Check off each step.
       advertised-vs-bound IP mismatches before going further (this is the
       same class of warning seen on the old gaming-PC setup — don't let it
       slide through unexamined here)
-- [ ] Confirm UCG-Fiber port forwards (7777-7810 UDP, 31982/31983 TCP) point
+- [ ] Confirm UCG-Max port forwards (7777-7810 UDP, 31982/31983 TCP) point
       at `dune-prod`'s actual static IP
 - [ ] From OUTSIDE your LAN (phone on cellular data, or ask a friend), test
       actual reachability — don't rely solely on internal `dune ports`/`dune


### PR DESCRIPTION
## Summary

Fixes #32. Repo-wide UCG-Fiber -> UCG-Max device-name correction, follow-up
to #31 (which already fixed `docs/02-network-setup.md`'s primary walkthrough
content).

## Changed

- `README.md:17`
- `docs/00-START-HERE.md` (5 lines: network summary, prereq checklist x2,
  directory map, order-of-operations step 2)
- `docs/01-proxmox-install.md:83`
- `docs/03-runbook-day-of.md` (2 lines: morning checklist, cutover checklist)

The two remaining `UCG-Fiber` mentions in `docs/02-network-setup.md` are
intentional -- part of the historical correction note explaining the
rename itself (added in #31/#33) -- left as-is.

**Scope note:** #32's original description also listed
`prompts/PROMPT-00-PREREQUISITES.md` and
`prompts/PROMPT-01-PROXMOX-AND-VMS.md`. Neither file exists in the current
repo state (`git log --all -- prompts/` shows no history either) -- nothing
to fix there. Also, `00-START-HERE.md:39`'s hardware-spec line, called out
in #32 as needing a UCG-Max-specific correction (5x 2.5GbE RJ45, 1 default
WAN, 2.3 Gbps IDS/IPS), does not currently contain any hardware-spec text at
all in the live repo (verified by reading the file directly) -- also
nothing to fix there. Both are pre-existing drift between #32's original
filing and the repo's current state, not anything skipped in this PR.

## Risk classification

**Low.** Documentation-only change, no scripts/CI/infra touched, no live
system affected. Blast radius: zero -- these are prose corrections to
already-correct instructions (the underlying UCG-Max config guidance in
`02-network-setup.md` was already correct; only the device name in
surrounding docs was stale).

## Verification

- `tests/no-personal-identifiers.sh` -- passed, no personal identifiers
- `pre-commit run --files <changed files>` -- all applicable hooks passed
  (merge-conflict, mixed-line-ending, end-of-file-fixer,
  trailing-whitespace, gitleaks, personal-identifier guard)
- `ggshield secret scan pre-commit` -- passed, no secrets found
- `trivy fs --scanners secret,misconfig --severity HIGH,CRITICAL` -- passed,
  clean
- `semgrep --config p/default` -- 6 findings, all in
  `.github/workflows/ci.yml` (unpinned action tags), pre-existing and
  unrelated to this diff. Not fixed here to avoid scope creep into #29
  (already tracks adding SHA-pinned CI jobs); noted as a comment on #29
  instead so the finding isn't lost.
- `grep -rn 'UCG-Fiber' .` -- confirms zero unintended references remain

## Documentation reviewed

This PR *is* the documentation fix. No other docs needed updating as a
result of this change.