### PR TITLE
docs: update Ubuntu Server target from 24.04 to 26.04 LTS

### DIFF
--- a/docs/00-START-HERE.md
+++ b/docs/00-START-HERE.md
@@ -127,7 +127,7 @@ says "see `docs/0N-...md`" for the full explanation of why a step exists.
    fails, fix CPU type before proceeding to real VMs. (Also covered as
    Phase 1 of `prompts/r740xd/01-proxmox-and-vms.md`.)
 5. Run `scripts/02-provision-vms.sh` on Proxmox to create `dune-prod` and
-   `dune-dev` VM shells, then install Ubuntu Server 24.04 LTS in each via the
+   `dune-dev` VM shells, then install Ubuntu Server 26.04 LTS in each via the
    Proxmox console (this part is interactive, no script covers OS install).
    (`prompts/r740xd/01-proxmox-and-vms.md` covers this end to end.)
 6. Inside each VM, run `scripts/03-vm-guest-bootstrap.sh` to install Docker

--- a/docs/03-runbook-day-of.md
+++ b/docs/03-runbook-day-of.md
@@ -14,9 +14,9 @@ Print this or keep it open on a second device. Check off each step.
 ## Provisioning
 
 - [ ] Run `scripts/02-provision-vms.sh` on the Proxmox host
-- [ ] Install Ubuntu Server 24.04 LTS on `dune-prod` (static IP on VLAN 20,
+- [ ] Install Ubuntu Server 26.04 LTS on `dune-prod` (static IP on VLAN 20,
       OpenSSH enabled)
-- [ ] Install Ubuntu Server 24.04 LTS on `dune-dev` (static IP on VLAN 21,
+- [ ] Install Ubuntu Server 26.04 LTS on `dune-dev` (static IP on VLAN 21,
       OpenSSH enabled)
 - [ ] SSH into `dune-prod`, run `scripts/03-vm-guest-bootstrap.sh`
 - [ ] SSH into `dune-dev`, run `scripts/03-vm-guest-bootstrap.sh`

--- a/prompts/r740xd/01-proxmox-and-vms.md
+++ b/prompts/r740xd/01-proxmox-and-vms.md
@@ -3,7 +3,7 @@
 This prompt runs ON THE PROXMOX HOST (via SSH or the web console at
 `https://<r740-mgmt-ip>:8006`) after booting from the Proxmox USB.
 It installs Proxmox VE, creates the two VMs, and installs Ubuntu Server
-24.04 on each.
+26.04 on each.
 
 ## Target Machine
 The Dell R740 Proxmox host, freshly booted from the Proxmox VE installer
@@ -55,12 +55,12 @@ apt update && apt full-upgrade -y
 
 ### 1.4 Upload ISO Files
 Via the Proxmox web UI: Datacenter → local → ISO Images → Upload
-Upload both ISOs (Proxmox + Ubuntu Server 24.04) if not already present.
+Upload both ISOs (Proxmox + Ubuntu Server 26.04) if not already present.
 
 Or via SCP from your dev machine:
 ```bash
 # From dev machine:
-scp /tmp/opencode/r740-isos/ubuntu-24.04.1-live-server-amd64.iso \
+scp /tmp/opencode/r740-isos/ubuntu-26.04-live-server-amd64.iso \
   root@<PROXMOX_MGMT_IP>:/var/lib/vz/template/iso/
 ```
 
@@ -132,7 +132,7 @@ qm create 101 \
   --net0 virtio,bridge=vmbr0,tag=20 \
   --scsihw virtio-scsi-pci \
   --scsi0 local-lvm:300 \
-  --ide2 local:iso/ubuntu-24.04.1-live-server-amd64.iso,media=cdrom \
+  --ide2 local:iso/ubuntu-26.04-live-server-amd64.iso,media=cdrom \
   --boot order=scsi0 \
   --ostype l26 \
   --agent enabled=1
@@ -150,7 +150,7 @@ qm create 102 \
   --net0 virtio,bridge=vmbr0,tag=21 \
   --scsihw virtio-scsi-pci \
   --scsi0 local-lvm:300 \
-  --ide2 local:iso/ubuntu-24.04.1-live-server-amd64.iso,media=cdrom \
+  --ide2 local:iso/ubuntu-26.04-live-server-amd64.iso,media=cdrom \
   --boot order=scsi0 \
   --ostype l26 \
   --agent enabled=1
@@ -166,7 +166,7 @@ qm set 102 --onboot 1 --startup order=2
 For EACH VM (do dune-prod first, then dune-dev):
 
 1. In Proxmox web UI: select VM → Console → Start
-2. Follow Ubuntu Server 24.04 installer:
+2. Follow Ubuntu Server 26.04 installer:
    - **Language**: English
    - **Keyboard**: US
    - **Network**: Manual IPv4
@@ -228,8 +228,8 @@ grep avx2 /proc/cpuinfo   # AVX2 visible in guest
 - [ ] Proxmox VE installed on the R740
 - [ ] No-subscription repo configured
 - [ ] AVX2 validated inside a test VM
-- [ ] dune-prod VM (VMID 101): 40 vCPU / 152 GB RAM, Ubuntu 24.04
-- [ ] dune-dev VM (VMID 102): 20 vCPU / 50 GB RAM, Ubuntu 24.04
+- [ ] dune-prod VM (VMID 101): 40 vCPU / 152 GB RAM, Ubuntu 26.04
+- [ ] dune-dev VM (VMID 102): 20 vCPU / 50 GB RAM, Ubuntu 26.04
 - [ ] Both VMs have Docker + Docker Compose plugin installed
 - [ ] `dune-awakening-selfhost-docker` cloned on both VMs
 - [ ] You can SSH into both VMs as `dune@<IP>`

--- a/prompts/tabr-tau/00-prerequisites.md
+++ b/prompts/tabr-tau/00-prerequisites.md
@@ -33,11 +33,13 @@ wget -P /tmp/opencode/r740-isos/ \
 sha256sum /tmp/opencode/r740-isos/proxmox-ve_8.2-1.iso
 ```
 
-### 3. Download Ubuntu Server 24.04 LTS ISO
+### 3. Download Ubuntu Server 26.04 LTS ISO
 ```bash
 wget -P /tmp/opencode/r740-isos/ \
-  https://releases.ubuntu.com/24.04/ubuntu-24.04.1-live-server-amd64.iso
-sha256sum /tmp/opencode/r740-isos/ubuntu-24.04.1-live-server-amd64.iso
+  https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso
+sha256sum /tmp/opencode/r740-isos/ubuntu-26.04-live-server-amd64.iso
+# Verify against the published checksum:
+# https://releases.ubuntu.com/26.04/SHA256SUMS
 ```
 
 ### 4. Prepare ACP Bot Secrets Backup
@@ -115,7 +117,7 @@ sudo dd if=/tmp/opencode/r740-isos/proxmox-ve_8.2-1.iso \
 
 ### 8. Final Checklist Before Moving to r740xd/01
 - [ ] Proxmox VE ISO downloaded and verified
-- [ ] Ubuntu Server 24.04 ISO downloaded and verified
+- [ ] Ubuntu Server 26.04 ISO downloaded and verified
 - [ ] Bootable Proxmox USB created
 - [ ] Bot secrets backed up to `~/r740-bot-backup/secrets/`
 - [ ] `values.env` filled in with real values

--- a/scripts/02-provision-vms.sh
+++ b/scripts/02-provision-vms.sh
@@ -6,14 +6,14 @@
 # PURPOSE:  Create the dune-prod and dune-dev VM shells with the correct
 #           CPU type, memory, vCPU pinning, and network bridge assignment.
 #           This does NOT install an OS - after this script, you attach the
-#           Ubuntu Server 24.04 ISO and install the OS interactively through
+#           Ubuntu Server 26.04 ISO and install the OS interactively through
 #           the Proxmox console (no way to script an OS install reliably
 #           here, and you shouldn't want to - you want to see it happen).
 #
 # PREREQ:   - 01-validate-avx2.sh has passed
 #           - VLANs 20 (Prod) and 21 (Dev) exist on your network/bridge
 #             config (see docs/02-network-setup.md)
-#           - Ubuntu Server 24.04 LTS ISO uploaded to Proxmox local storage
+#           - Ubuntu Server 26.04 LTS ISO uploaded to Proxmox local storage
 #             (Datacenter -> local storage -> ISO Images -> Upload)
 #
 # SIZING RATIONALE (2026-08-07 revision — 2x Sietch @40p + 4x DD + dynamics):
@@ -53,7 +53,7 @@ set -euo pipefail
 # --- Adjust these if your environment differs ------------------------------
 STORAGE="local-lvm"          # where VM disks live; check `pvesm status` if unsure
 ISO_STORAGE="local"
-UBUNTU_ISO="ubuntu-24.04-live-server-amd64.iso"   # must already be uploaded
+UBUNTU_ISO="ubuntu-26.04-live-server-amd64.iso"   # must already be uploaded
 
 PROD_VMID=101
 PROD_NAME="dune-prod"
@@ -176,7 +176,7 @@ echo "=== Both VM shells created ==="
 echo
 echo "NEXT STEPS (manual, via Proxmox web UI):"
 echo "1. Open the web UI, select VM $PROD_VMID ($PROD_NAME), click Console"
-echo "2. Start the VM, install Ubuntu Server 24.04 LTS interactively"
+echo "2. Start the VM, install Ubuntu Server 26.04 LTS interactively"
 echo "   - Set hostname: dune-prod"
 echo "   - Set a static IP on the VLAN 20 subnet (e.g. 192.168.20.10/24,"
 echo "     gateway 192.168.20.1) - this is the IP your router forwards to"

--- a/scripts/03-vm-guest-bootstrap.sh
+++ b/scripts/03-vm-guest-bootstrap.sh
@@ -3,7 +3,7 @@
 # 03-vm-guest-bootstrap.sh
 #
 # RUN THIS: INSIDE each VM (dune-prod AND dune-dev), after Ubuntu Server
-#           24.04 is installed and you can SSH in. Run it once per VM.
+#           26.04 is installed and you can SSH in. Run it once per VM.
 # PURPOSE:  Confirm AVX2 is visible inside the guest (final sanity check),
 #           install Docker, clone the dune-awakening-selfhost-docker repo,
 #           and prep the directory structure. Stops BEFORE running `dune


### PR DESCRIPTION
## Summary

Closes #51. Updates all VM-provisioning references from Ubuntu Server
24.04 LTS to 26.04 LTS (Resolute Raccoon), the current latest LTS release
(released 2026-04-23) as of this writing.

## Verified before changing

- Confirmed 26.04 is genuinely the latest LTS via releases.ubuntu.com's
  own release list (25.10 is an interim release, not LTS).
- Confirmed the exact live-server ISO filename
  (`ubuntu-26.04-live-server-amd64.iso`) and its published SHA256
  checksum via `releases.ubuntu.com/26.04/` and its `SHA256SUMS` file.
- Confirmed Docker's own apt repository already has a `resolute/`
  codename directory (Ubuntu 26.04's codename) -- `scripts/03-vm-guest-
  bootstrap.sh`'s Docker install already derives `$VERSION_CODENAME`
  dynamically from `/etc/os-release` rather than hardcoding a codename,
  so no script *logic* change was needed, only the stale header comment.

## Changed

- `scripts/02-provision-vms.sh` -- ISO filename variable, header comments
- `scripts/03-vm-guest-bootstrap.sh` -- header comment only
- `docs/03-runbook-day-of.md`, `docs/00-START-HERE.md`
- `prompts/tabr-tau/00-prerequisites.md` -- download URL, checksum
  reference, checklist item
- `prompts/r740xd/01-proxmox-and-vms.md` -- ISO upload/attach commands,
  installer step, state-after-completion checklist

## Deliberately NOT changed

`prompts/tabr-tau/00-prerequisites.md`'s "Target Machine" line ("Your
current dev machine (Ubuntu 24.04)") describes the dev machine's
*existing, already-installed* OS, not a provisioning choice -- left as-is
since changing it would misrepresent that machine's actual current state.

## Risk classification

**Low.** Documentation/script-comment changes to not-yet-executed
provisioning scripts -- `qm list` on the live R740 confirms zero VMs
exist, so this changes what *will* be installed, not anything already
running.

## Verification

- `tests/no-personal-identifiers.sh` -- passed
- `shellcheck -S warning` on both changed scripts -- clean
- `bash -n` syntax check -- clean
- Markdown code-fence balance across all changed files -- even
- CI's own broken-relative-link check logic run manually against
  `docs/*.md`/`README.md` -- zero broken links
- `ggshield secret scan`, `trivy fs --scanners secret,misconfig` -- clean

## Documentation reviewed

This PR is itself the documentation-currency fix (Ubuntu version drift).
No other docs required updates as a result.
