### PR TITLE
fix: personal-identifier guard false-positives on lines being REMOVED, not added

### DIFF
--- a/tests/no-personal-identifiers.sh
+++ b/tests/no-personal-identifiers.sh
@@ -57,10 +57,21 @@ else
   SCAN_TARGET="tree"
 fi
 
+# When scanning a diff, only look at ADDED lines (prefixed with a single
+# '+', excluding the '+++ b/path' file-header line). Scanning the whole
+# diff text would also match a denylisted value that appears on a
+# REMOVED ('-') line or in unchanged context around a hunk -- i.e. fixing
+# a bad value by deleting it would itself trigger a false "found in
+# diff" block, exactly backwards from what this guard is for. Found via
+# the ported copy of this script in arrakis-control-panel#165, when
+# removing real personal identifiers there tripped this guard on the
+# deletions themselves.
+ADDED_LINES="$(printf '%s\n' "$DIFF_CONTENT" | grep -E '^\+' | grep -vE '^\+\+\+ ' || true)"
+
 found=0
 for pattern in "${DENYLIST[@]}"; do
   if [ "$SCAN_TARGET" = "staged" ] || [ "$SCAN_TARGET" = "ci-diff" ]; then
-    if printf '%s' "$DIFF_CONTENT" | grep -qE "$pattern"; then
+    if printf '%s' "$ADDED_LINES" | grep -qE "$pattern"; then
       echo "BLOCKED: $SCAN_TARGET changes contain a known personal identifier matching: $pattern"
       found=1
     fi


### PR DESCRIPTION
## Summary

Closes #53. `tests/no-personal-identifiers.sh`'s diff-scanning mode
scanned the entire diff text, including removed (`-`) lines and
unchanged hunk-header context. Removing a denylisted value from a file
-- exactly what this guard exists to encourage -- could itself trigger a
false "found in diff" block.

## How this was found

Discovered while porting this script to `arrakis-control-panel`
(#164/PR #165) -- a PR removing a real OCI IP and admin console hostname
from two files failed its own newly-added guard, because the deletions
themselves matched the denylist pattern in the raw diff text.

## Fix

Scan only ADDED lines (`^\+`, excluding the `+++ b/path` file-header)
instead of the full diff text.

## Risk classification

**Low.** Fixes a false-positive; does not weaken detection of genuinely
new introductions.

## Verification

- Staged a test file containing a denylisted value -- guard still
  correctly blocks it.
- Ran against this repo's own clean `main` (no staged changes, no CI) --
  passes clean.
- Simulated the CI diff-scan path directly (`CI=1 GITHUB_BASE_REF=main`)
  -- passes clean.
- `shellcheck -S warning` -- clean.
