### PR TITLE
fix: scripts/11-e2e-verify.sh V5/V10 affinity checks hardcode stale contiguous CPU ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ introduced them, in Keep a Changelog style, newest first.
 - Fixed a duplicated `## Troubleshooting` header in the former
   `tabr-tau/04-e2e-verification.md` (now resolved by the file split
   above).
+- `scripts/11-e2e-verify.sh` checks V5/V10 (CPU affinity) hardcoded the
+  old, already-corrected contiguous-range affinity values (`0-19`,
+  `20-29`) from before `scripts/02-provision-vms.sh`'s NUMA fix, which
+  now pins VMs to a runtime-detected, host-specific, interleaved CPU
+  list instead. As written, both checks would always fail once VMs are
+  actually provisioned with the corrected affinity, falsely reporting
+  the deployment as NOT READY FOR PRODUCTION. Replaced with a structural
+  check (all-even CPU IDs for dune-prod/socket 0, all-odd for
+  dune-dev/socket 1, explicitly rejecting stale range syntax like
+  `0-19`) that doesn't depend on this host's specific CPU numbering.
+  (#62)
 
 ### Fixed
 
@@ -207,4 +218,3 @@ re-added with their own verification (matching this file's existing
 discipline of citing what was actually checked, not just claimed) once
 confirmed against real system state.
 -->
-

--- a/scripts/11-e2e-verify.sh
+++ b/scripts/11-e2e-verify.sh
@@ -139,8 +139,26 @@ check "V3" CRITICAL "dune-prod memory (expect 152 GB)" \
 check "V4" CRITICAL "dune-prod cores (expect 40)" \
   "$PROXMOX" "qm config 101 | grep '^cores:'" "40"
 
-check "V5" CRITICAL "dune-prod CPU affinity to socket 0" \
-  "$PROXMOX" "qm config 101 | grep '^affinity:'" "0-19"
+## V5/V10 fix (issue #62, 2026-08-14): scripts/02-provision-vms.sh detects
+## each NUMA node's real CPU list at runtime via `lscpu -p=CPU,NODE`
+## because this host's actual topology is interleaved (socket 0 = all
+## even logical CPU IDs, socket 1 = all odd IDs), not two contiguous
+## blocks -- see that script's own header comment. The exact CPU list is
+## therefore host-specific and can't be hardcoded as a fixed range like
+## the previous "0-19"/"20-29" (which would now always fail once VMs are
+## actually pinned with the corrected values). Check the structural
+## property instead: every CPU ID in dune-prod's affinity is even
+## (socket 0), every CPU ID in dune-dev's affinity is odd (socket 1).
+## NOTE: this deliberately rejects any "-" range syntax (e.g. a stale
+## "0-19") as MIXED/invalid up front -- scripts/02-provision-vms.sh always
+## emits a flat comma list of individual detected CPU IDs, never a range,
+## so a "-" appearing here means either a manually-typed contiguous range
+## (exactly the bug this fix replaces) or Proxmox's own range-compaction
+## of a list that happens to be contiguous, neither of which this repo's
+## provisioning path should ever produce -- treat both as a real finding
+## worth investigating rather than silently passing.
+check "V5" CRITICAL "dune-prod CPU affinity: all-even CPU IDs (this host's socket 0 under its interleaved NUMA topology -- exact IDs are host-specific, see scripts/02-provision-vms.sh)" \
+  "$PROXMOX" "AFF=\$(qm config 101 | sed -n 's/^affinity: *//p'); if [ -z \"\$AFF\" ]; then echo NO_AFFINITY; elif echo \"\$AFF\" | grep -q '-'; then echo RANGE_SYNTAX_UNEXPECTED; elif echo \"\$AFF\" | tr ',' '\n' | grep -qE '[13579]\$'; then echo MIXED; else echo ALL_EVEN; fi" "ALL_EVEN"
 
 check "V6" WARN "dune-prod bridge VLAN-aware" \
   "$PROXMOX" "grep 'bridge-vlan-aware' /etc/network/interfaces" "yes"
@@ -154,8 +172,8 @@ check "V8" CRITICAL "dune-dev memory (expect 50 GB)" \
 check "V9" CRITICAL "dune-dev cores (expect 20)" \
   "$PROXMOX" "qm config 102 | grep '^cores:'" "20"
 
-check "V10" CRITICAL "dune-dev CPU affinity to socket 1" \
-  "$PROXMOX" "qm config 102 | grep '^affinity:'" "20-29"
+check "V10" CRITICAL "dune-dev CPU affinity: all-odd CPU IDs (this host's socket 1 under its interleaved NUMA topology -- exact IDs are host-specific, see scripts/02-provision-vms.sh)" \
+  "$PROXMOX" "AFF=\$(qm config 102 | sed -n 's/^affinity: *//p'); if [ -z \"\$AFF\" ]; then echo NO_AFFINITY; elif echo \"\$AFF\" | grep -q '-'; then echo RANGE_SYNTAX_UNEXPECTED; elif echo \"\$AFF\" | tr ',' '\n' | grep -qE '[02468]\$'; then echo MIXED; else echo ALL_ODD; fi" "ALL_ODD"
 
 check "V11" WARN "VM auto-start enabled and ordered" \
   "$PROXMOX" "qm config 101 | grep '^onboot:\|^startup:' | wc -l" "2"


### PR DESCRIPTION
Closes #62.

## Summary
`scripts/02-provision-vms.sh` was corrected (2026-08-13) to detect each NUMA node's real CPU list at runtime via `lscpu -p=CPU,NODE`, since this host's actual topology is interleaved (socket 0 = all even logical CPU IDs, socket 1 = all odd IDs), not two contiguous blocks. That fix was never propagated to `11-e2e-verify.sh`'s V5/V10 checks, which still hardcoded the old, already-known-wrong contiguous-range expectations (`0-19`, `20-29`). Both are `CRITICAL` checks — as written, they would always fail once VMs are actually provisioned with the corrected affinity, falsely reporting the deployment as NOT READY FOR PRODUCTION.

## Risk classification
**Low.** Verification-script-only change. The script hasn't been run against fully-provisioned VMs yet (no impact on already-running infrastructure), but this was a real landmine that would have blocked go-live sign-off with a false CRITICAL failure the first time the script was actually run post-provisioning.

## What changed
- `scripts/11-e2e-verify.sh`: V5/V10 replaced with a structural check (all-even CPU IDs for dune-prod/socket 0, all-odd for dune-dev/socket 1) instead of a fixed range, since the exact CPU IDs are host-specific. Explicitly rejects stale dash-range syntax as `RANGE_SYNTAX_UNEXPECTED` rather than silently mis-evaluating it (caught in review — a naive last-character-parity check would have falsely passed a leftover `20-29`).
- Also fixed the script's file permissions (`644` → `755`) — inconsistent with every other script in `scripts/`, caught by this session's `pre-commit run`.
- `CHANGELOG.md` updated.

## Docs reviewed
Only this script needed updating for this bug's scope; no prompt/doc text references the specific affinity values being checked.

## Verification
- `bash -n` syntax check — clean
- `shellcheck -S warning` — clean
- New shell logic hand-tested against all-even/all-odd/mixed/empty/stale-range inputs, and simulated against a mocked `qm config` remote command matching how `check()` actually invokes it over SSH
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff