### PR TITLE
docs: rewrite prompts/tabr-tau/* and prompts/r740xd/* as direct agent instructions

### DIFF
--- a/prompts/r740xd/01-proxmox-and-vms.md
+++ b/prompts/r740xd/01-proxmox-and-vms.md
@@ -1,12 +1,15 @@
 # R740XD-01: Proxmox Install + VM Provisioning
 
-This prompt runs in its own session, ON THE PROXMOX HOST (via SSH or the
-web console at `https://<r740-mgmt-ip>:8006`). It covers everything from
-Proxmox VE installation media through both VM shells being created and
-bootstrapped — all ISO acquisition, install steps, and configuration
-happen here, not in any `tabr-tau/` prompt (see issue #59's session
-boundary: Tabr-Tau sessions gather credentials/config only, R740xd
-sessions do all actual install/configuration work).
+You are an LLM coding agent running in your own session, ON THE PROXMOX
+HOST (via SSH or the web console at `https://<r740-mgmt-ip>:8006`). Your
+job in this session covers everything from Proxmox VE installation media
+through both VM shells being created and bootstrapped — all ISO
+acquisition, install steps, and configuration happen here, not in any
+`tabr-tau/` prompt (see issue #59's session boundary: Tabr-Tau sessions
+gather credentials/config only, R740xd sessions do all actual
+install/configuration work). If asked to do dev-machine-only gathering
+work in this session, redirect to the correct `tabr-tau/` prompt instead
+of doing it here.
 
 ## Target Machine
 The Dell R740 Proxmox host. Access via:
@@ -16,26 +19,28 @@ The Dell R740 Proxmox host. Access via:
   (this exact hardware's iDRAC9 has been used for exactly this before —
   see `docs/05-dell-support-case-boot-failure.md`), or a physical USB
   installer if iDRAC access isn't available. Either way, this is R740xd
-  work, not something to prepare on the dev machine beforehand.
+  work — do not attempt any of it from a `tabr-tau/` session.
 
-## Pre-Requisites
-- `tabr-tau/00-prerequisites.md` completed (values.env filled, Funcom
-  tokens ready, bot secrets staged) — run in ITS OWN separate session
-- R740 racked, powered, network cabled to UCG-Max
-- UCG-Max VLANs configured per `docs/02-network-setup.md`
-- Read `docs/01-proxmox-install.md` for the full step-by-step
+## Before You Start, Confirm
+- `tabr-tau/00-prerequisites.md` has been completed (values.env filled,
+  Funcom tokens ready, bot secrets staged) — ask the user if you have no
+  direct evidence, since this was run in a separate session
+- R740 is racked, powered, network cabled to UCG-Max
+- UCG-Max VLANs are configured per `docs/02-network-setup.md`
+- Read `docs/01-proxmox-install.md` for the full step-by-step reference
 
-## State Before Starting
+## Determine Current State Before Acting
 The R740 is powered on. Proxmox VE may or may not be installed yet —
-Phase 0 below covers the case where it isn't; skip to Phase 1 if it is
-(confirm with `pveversion` over SSH or by checking whether the web UI at
-`https://<r740-mgmt-ip>:8006` is reachable).
+Phase 0 below covers the case where it isn't; skip to Phase 1 if it is.
+Confirm which situation you're in with `pveversion` over SSH or by
+checking whether the web UI at `https://<r740-mgmt-ip>:8006` is
+reachable — do not assume either state without checking.
 
 ## Phase 0: Acquire Install Media (if Proxmox VE is not yet installed)
 
 ### 0.1 Download the Proxmox VE ISO
-On any machine with a browser (this can be your dev machine, since it's
-just a download, not R740-side configuration):
+This can be done from any machine with a browser, including the dev
+machine, since it's just a download, not R740-side configuration:
 ```bash
 wget -P /tmp/opencode/r740-isos/ \
   https://enterprise.proxmox.com/iso/proxmox-ve_8.2-1.iso
@@ -43,11 +48,14 @@ wget -P /tmp/opencode/r740-isos/ \
 # https://www.proxmox.com/en/downloads
 sha256sum /tmp/opencode/r740-isos/proxmox-ve_8.2-1.iso
 ```
+Report the checksum and confirm it matches the published value before
+proceeding — do not continue with an unverified ISO.
 
 ### 0.2 Boot From It
 - **Physical USB**: `sudo dd if=/tmp/opencode/r740-isos/proxmox-ve_8.2-1.iso of=/dev/sdX bs=4M status=progress conv=fsync`
   (confirm `/dev/sdX` via `lsblk` first — this destroys all data on the
-  target device), then boot the R740 from it.
+  target device; get explicit user confirmation of the device before
+  running `dd`), then boot the R740 from it.
 - **iDRAC Virtual Media** (no physical USB needed): iDRAC web UI →
   Virtual Console → Virtual Media → mount the ISO, then reboot the R740
   and select the virtual optical drive as the boot device. See
@@ -58,28 +66,34 @@ sha256sum /tmp/opencode/r740-isos/proxmox-ve_8.2-1.iso
 ## Phase 1: Install Proxmox VE
 
 ### 1.1 BIOS Check (if not already done)
-During POST, press F2 → System BIOS Settings → Processor Settings:
+Ask the user to check, during POST (press F2 → System BIOS Settings →
+Processor Settings), that:
 - Virtualization Technology: Enabled
 - VT-d: Enabled
 - Logical Processor: Enabled
 - Power Profile: Maximum Performance
 - C-States: Disabled
 
+You cannot do this yourself — it happens before any OS is reachable
+over the network.
+
 ### 1.2 Run the Installer
-Follow the Proxmox VE installer:
+Walk the user through the Proxmox VE installer (this is interactive and
+console-only; you cannot drive it yourself remotely):
 1. Select "Install Proxmox VE" from boot menu
 2. Accept EULA
 3. **Target disk**: Select the RAID1 mirror (should show ~1.92 TB)
 4. Set country/timezone/keyboard
-5. **Root password**: Generate and save to password manager
-6. **Network**: Set to your management VLAN IP per values.env
+5. **Root password**: Generate and have the user save it to their
+   password manager
+6. **Network**: Set to the management VLAN IP per values.env
    - IP: `$PROXMOX_MGMT_IP/24`
    - Gateway: `192.168.30.1`
    - DNS: `1.1.1.1`
    - Hostname: `r740-pve`
 
 ### 1.3 Post-Install: Switch to No-Subscription Repository
-After reboot, SSH into the Proxmox host as root:
+After reboot, SSH into the Proxmox host as root and run:
 ```bash
 # Replace enterprise repo with community (free)
 sed -i 's/^deb/#deb/' /etc/apt/sources.list.d/pve-enterprise.list
@@ -87,11 +101,13 @@ echo "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" \
   > /etc/apt/sources.list.d/pve-no-subscription.list
 apt update && apt full-upgrade -y
 ```
+Report the outcome — confirm `apt update` succeeds with no repo errors
+before proceeding.
 
 ### 1.4 Download and Upload the Ubuntu Server ISO
-This is genuinely R740xd-side work now (not a Tabr-Tau step) — download
-directly onto the Proxmox host itself, since it has its own internet
-access and this avoids an unnecessary dev-machine hop entirely:
+This is R740xd-side work, not a Tabr-Tau step — download directly onto
+the Proxmox host itself, since it has its own internet access and this
+avoids an unnecessary dev-machine hop entirely:
 ```bash
 # Directly on the Proxmox host:
 curl -sL "https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso" \
@@ -100,10 +116,13 @@ curl -sL "https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso" 
 # https://releases.ubuntu.com/26.04/SHA256SUMS
 sha256sum /var/lib/vz/template/iso/ubuntu-26.04-live-server-amd64.iso
 ```
+Report the checksum comparison result before proceeding — do not use an
+unverified ISO for VM installs.
 
-Or via the Proxmox web UI: Datacenter → local → ISO Images → Upload.
+Alternative: via the Proxmox web UI: Datacenter → local → ISO Images → Upload.
 
 ### 1.5 Run AVX2 Validation
+Run:
 ```bash
 # On the Proxmox host, as root:
 cd /root
@@ -111,11 +130,11 @@ cd /root
 bash /path/to/scripts/01-validate-avx2.sh
 ```
 
-**Note on running this non-interactively:** the script's own `read -p`
-confirmation prompt assumes an interactive console session watching the
-test VM boot. If running this from an automated/agent-driven session
-instead, verify AVX2 passthrough directly via QEMU's own QMP API instead
-of the console-based check:
+**Note for you as an agent driving this non-interactively:** the
+script's own `read -p` confirmation prompt assumes an interactive
+console session watching the test VM boot. Since you're running this
+from an automated/agent-driven session, verify AVX2 passthrough directly
+via QEMU's own QMP API instead of the console-based check:
 ```bash
 # After the script creates and starts the disposable test VM (e.g. VMID 900):
 python3 -c "
@@ -140,42 +159,43 @@ print('avx2 exposed to guest:', props.get('avx2'))
 # Expected: avx2 exposed to guest: True
 ```
 
-**VERIFY**: The script reports "AVX2 validation complete" and the disposable
-test VM shows AVX2 in `/proc/cpuinfo` inside the guest. If it fails, DO NOT
-PROCEED — check CPU type is "host" in the VM config.
+Confirm the script reports "AVX2 validation complete" and that the
+disposable test VM shows AVX2 in `/proc/cpuinfo` inside the guest, and
+report this back to the user. **If either check fails, stop — do not
+proceed to VM creation.** Check that CPU type is "host" in the VM config
+and fix before continuing.
 
 ## Phase 2: Configure VM Networking
 
-### 2.0 Configure VLAN-Aware Bridge (CRITICAL — skip at your peril)
+### 2.0 Configure VLAN-Aware Bridge (CRITICAL — do not skip)
 
 **This is the most important networking step in the entire deployment.**
 VMs use `tag=20` and `tag=21` which emit 802.1Q-tagged frames. The bridge
 must be VLAN-aware or those tags are silently ignored.
 
-**Do not blindly copy a bridge-port name or VLAN list from an example —
-confirm both against this specific host first:**
+**Do not copy a bridge-port name or VLAN list from an example below
+without confirming both against this specific host first:**
 ```bash
-# Confirm your actual data-NIC interface name (varies by host/NIC driver;
+# Confirm the actual data-NIC interface name (varies by host/NIC driver;
 # do NOT assume "eno1" -- this deployment's actual R740 uses "nic0", a
 # different name entirely, confirmed via `ip link show` before editing):
 ip link show
 cat /etc/network/interfaces   # see which interface vmbr0 already uses as bridge-ports
 
-# Confirm your actual configured VLANs via the UCG-Max (or the UniFi
+# Confirm the actual configured VLANs via the UCG-Max (or the UniFi
 # Network Integration API) rather than assuming a fixed list -- this
 # deployment only has 20 (Prod), 21 (Dev), 30 (Mgmt) configured, NOT a
 # VLAN 10, despite an earlier draft of this doc assuming one existed.
 ```
 
-Edit `/etc/network/interfaces` **in place** (add these three lines to the
-existing `vmbr0` stanza — do not blindly append a second, duplicate
-`vmbr0` block with `cat >>`, which creates a conflicting second
-definition):
+Edit `/etc/network/interfaces` **in place** (add these two lines to the
+existing `vmbr0` stanza — do not append a second, duplicate `vmbr0`
+block with `cat >>`, which creates a conflicting second definition):
 ```
 	bridge-vlan-aware yes
 	bridge-vids 20 21 30
 ```
-using your host's actual `bridge-ports` value and actual VLAN list from
+using the host's actual `bridge-ports` value and actual VLAN list from
 the check above, then apply:
 ```bash
 ifreload -a
@@ -196,22 +216,25 @@ iface vmbr0 inet static
 	bridge-vids 20 21 30
 ```
 
-**VERIFY:** `bridge vlan show` should list your actual VLANs (20, 21, 30
-on this deployment) on both the bridge-port interface and `vmbr0`,
-alongside VLAN 1 (or whatever your native/untagged VLAN is) still marked
-`PVID Egress Untagged`. If the new VLANs are missing, the bridge is NOT
-VLAN-aware and inter-VM isolation does not exist — STOP and fix before
-continuing. If your management connection drops after `ifreload -a`,
-your backed-up copy of `/etc/network/interfaces` should be restored via
-the Proxmox console (not SSH, which will be down) — always back up the
-file before editing it, and consider a scheduled revert-and-reload
-safety net (e.g. a `sleep N && cp backup /etc/network/interfaces &&
-ifreload -a` backgrounded process) if working from a remote/agent-driven
-session with no console fallback readily available.
+Before editing, back up `/etc/network/interfaces` and consider a
+scheduled revert-and-reload safety net (e.g. a `sleep N && cp backup
+/etc/network/interfaces && ifreload -a` backgrounded process), since
+you're likely operating from a remote/agent-driven session with no
+console fallback readily available if the management connection drops.
 
-**Cabling:** Use ONE UCG-Max LAN port configured as a trunk (tagged for
-your actual VLAN list). Connect one R740 NIC to it. The remaining NICs
-are spare.
+After applying, run `bridge vlan show` and confirm it lists the actual
+VLANs (20, 21, 30 on this deployment) on both the bridge-port interface
+and `vmbr0`, alongside VLAN 1 (or whatever the native/untagged VLAN is)
+still marked `PVID Egress Untagged`. **If the new VLANs are missing, the
+bridge is NOT VLAN-aware and inter-VM isolation does not exist — stop and
+fix before continuing; do not proceed to Phase 3.** If the management
+connection drops after `ifreload -a`, tell the user the backed-up copy of
+`/etc/network/interfaces` needs to be restored via the Proxmox console
+(not SSH, which will be down).
+
+**Cabling:** confirm with the user that one UCG-Max LAN port is
+configured as a trunk (tagged for the actual VLAN list) and one R740 NIC
+is connected to it. The remaining NICs are spare.
 
 ## Phase 3: Create VMs
 
@@ -220,15 +243,18 @@ Transfer `scripts/02-provision-vms.sh` to the Proxmox host and run it:
 ```bash
 bash /path/to/scripts/02-provision-vms.sh
 ```
+This is the preferred path — it already handles NUMA detection
+automatically. Only fall back to the manual commands below if the script
+is genuinely inaccessible.
 
-If you don't have the script accessible, run the equivalent commands.
-**Do not hardcode a contiguous affinity range like `0-19`/`20-29` for the
-NUMA pinning below** — on hosts where the kernel numbers logical CPUs
-interleaved across sockets (this exact class of 2-socket Xeon hardware
-does exactly this: socket 0 = all even logical CPU IDs, socket 1 = all
-odd IDs, NOT two contiguous blocks), a contiguous range silently mixes
-both sockets roughly 50/50, achieving none of the single-socket isolation
-this sizing depends on. Detect the real per-node CPU list first:
+**Do not hardcode a contiguous affinity range like `0-19`/`20-29` for
+NUMA pinning if you do fall back to manual commands** — on hosts where
+the kernel numbers logical CPUs interleaved across sockets (this exact
+class of 2-socket Xeon hardware does exactly this: socket 0 = all even
+logical CPU IDs, socket 1 = all odd IDs, NOT two contiguous blocks), a
+contiguous range silently mixes both sockets roughly 50/50, achieving
+none of the single-socket isolation this sizing depends on. Detect the
+real per-node CPU list first:
 ```bash
 NODE0_CPUS="$(lscpu -p=CPU,NODE 2>/dev/null | grep -v '^#' | awk -F, '$2==0 {print $1}' | paste -sd, -)"
 NODE1_CPUS="$(lscpu -p=CPU,NODE 2>/dev/null | grep -v '^#' | awk -F, '$2==1 {print $1}' | paste -sd, -)"
@@ -236,6 +262,7 @@ echo "Node 0: $NODE0_CPUS"
 echo "Node 1: $NODE1_CPUS"
 ```
 
+Manual fallback commands, using the detected lists above:
 ```bash
 # dune-prod (VMID 101) — 40 vCPU, 152 GB RAM, socket 0 (ALL of node 0's CPUs)
 qm create 101 \
@@ -280,21 +307,27 @@ qm set 101 --onboot 1 --startup order=1
 qm set 102 --onboot 1 --startup order=2
 ```
 
-**Or just run `scripts/02-provision-vms.sh` directly** — it already
-handles this NUMA detection automatically and is the preferred path;
-the manual commands above are only a fallback for when the script isn't
-accessible.
+**Known bug (issue #61, not yet fixed in the script as of 2026-08-14):**
+`--boot order=scsi0` never includes `ide2` (the installer ISO) in boot
+order, so the VM shows "no boot media" on first boot. Work around this by
+running, immediately after creation and before first boot:
+```bash
+qm set 101 --boot 'order=ide2;scsi0'
+qm set 102 --boot 'order=ide2;scsi0'
+```
+Reset back to `order=scsi0` on each VM after its OS install completes, so
+subsequent boots don't try the CD-ROM first.
 
-**Verified on this exact deployment (2026-08-14):** both VM shells were
-created successfully using the script (not the manual fallback), with
-`dune-prod` correctly pinned to all 40 of node 0's logical CPUs and
-`dune-dev` to the first 20 of node 1's — confirmed via `qm config
-101`/`qm config 102` showing the real detected CPU lists, not a guessed
-range.
+After creating both VMs, run `qm config 101` and `qm config 102` and
+confirm the CPU affinity lists match the real detected per-node CPU
+lists from above, not a guessed contiguous range — report this
+confirmation back to the user.
 
-### 2.2 Install Ubuntu Server on Each VM
+### 3.2 Install Ubuntu Server on Each VM
 
-For EACH VM (do dune-prod first, then dune-dev):
+For EACH VM (do dune-prod first, then dune-dev), this is interactive
+console work — walk the user through it, or if you have console access
+yourself, drive it directly:
 
 1. In Proxmox web UI: select VM → Console → Start
 2. Follow Ubuntu Server 26.04 installer:
@@ -307,12 +340,24 @@ For EACH VM (do dune-prod first, then dune-dev):
    - **Profile**:
      - Name: `dune` (for both VMs — same username)
      - Hostname: `dune-prod` / `dune-dev`
-     - Password: generate + store in password manager
+     - Password: generate + have the user store it in their password
+       manager
    - **SSH**: Enable "Install OpenSSH server"
    - **Snaps**: Skip (no snaps needed)
 
-### 2.3 Verify SSH Access
-From your dev machine, confirm you can reach both VMs (via VPN or Trusted-LAN):
+**Known issue not yet tracked as a GitHub issue as of 2026-08-14:** the
+Ubuntu installer's netplan config
+(`/etc/netplan/00-installer-config.yaml`) has been observed to write
+`match:`/`set-name:` for the network interface but NOT write the
+`addresses:` entry for the static IP entered during install, despite the
+installer prompting for it. Before rebooting out of the installer, check
+`ip addr show` matches the intended static IP; if it doesn't, fix the
+netplan file and run `netplan apply` before proceeding, rather than
+discovering the VM is unreachable after reboot.
+
+### 3.3 Verify SSH Access
+From wherever you're running this session, confirm you can reach both
+VMs:
 ```bash
 ssh dune@192.168.20.10 "hostname && free -h | head -2 && nproc"
 # Expected: dune-prod, 152 GB RAM, 40 CPUs
@@ -320,22 +365,23 @@ ssh dune@192.168.20.10 "hostname && free -h | head -2 && nproc"
 ssh dune@192.168.21.10 "hostname && free -h | head -2 && nproc"
 # Expected: dune-dev, 50 GB RAM, 20 CPUs
 ```
+Report the actual output and compare it explicitly against the expected
+values above — do not assume it matches without checking.
 
-If you can't reach the VMs from your dev machine, use the Proxmox console
-or ensure your dev machine is on the Trusted-LAN VLAN (192.168.10.0/24)
-and the firewall allows Trusted-LAN → Prod / Trusted-LAN → Dev per
-`docs/02-network-setup.md` Step 3.
+If you can't reach the VMs, use the Proxmox console instead, or confirm
+your access path is on the Trusted-LAN VLAN (per `docs/02-network-setup.md`)
+and that the firewall allows Trusted-LAN → Prod / Trusted-LAN → Dev per
+that doc's Step 3.
 
-## Phase 3: Bootstrap Both VMs
+## Phase 4: Bootstrap Both VMs
 
-### 3.1 Transfer Bootstrap Script
-From your dev machine:
+### 4.1 Transfer Bootstrap Script
 ```bash
 scp ~/r740-deployment/scripts/03-vm-guest-bootstrap.sh dune@192.168.20.10:~/
 scp ~/r740-deployment/scripts/03-vm-guest-bootstrap.sh dune@192.168.21.10:~/
 ```
 
-### 3.2 Run Bootstrap on Both VMs
+### 4.2 Run Bootstrap on Both VMs
 ```bash
 # On dune-prod:
 ssh dune@192.168.20.10 "bash ~/03-vm-guest-bootstrap.sh"
@@ -345,31 +391,38 @@ ssh dune@192.168.21.10 "bash ~/03-vm-guest-bootstrap.sh"
 ```
 
 This installs Docker, Docker Compose plugin, and clones the
-`dune-awakening-selfhost-docker` repo from the latest GitHub release tarball.
+`dune-awakening-selfhost-docker` repo from the latest GitHub release
+tarball.
 
-**VERIFY on each VM:**
+**Verify on each VM** by running:
 ```bash
 docker --version          # Docker version 26+
 docker compose version    # Compose plugin present
 ls ~/dune-awakening-selfhost-docker/runtime/scripts/dune  # CLI exists
 grep avx2 /proc/cpuinfo   # AVX2 visible in guest
 ```
+Report each check's actual result explicitly — do not report this phase
+complete until all four checks pass on both VMs.
 
-## State After Completion
-- [ ] Proxmox VE installed on the R740
-- [ ] No-subscription repo configured
-- [ ] AVX2 validated inside a test VM
-- [ ] dune-prod VM (VMID 101): 40 vCPU / 152 GB RAM, Ubuntu 26.04
-- [ ] dune-dev VM (VMID 102): 20 vCPU / 50 GB RAM, Ubuntu 26.04
-- [ ] Both VMs have Docker + Docker Compose plugin installed
-- [ ] `dune-awakening-selfhost-docker` cloned on both VMs
-- [ ] You can SSH into both VMs as `dune@<IP>`
+## What to Report Back When This Prompt Is Done
+Confirm and report each of the following explicitly, not just "looks
+done":
+- Proxmox VE installed on the R740
+- No-subscription repo configured
+- AVX2 validated inside a test VM
+- dune-prod VM (VMID 101): 40 vCPU / 152 GB RAM, Ubuntu 26.04
+- dune-dev VM (VMID 102): 20 vCPU / 50 GB RAM, Ubuntu 26.04
+- Both VMs have Docker + Docker Compose plugin installed
+- `dune-awakening-selfhost-docker` cloned on both VMs
+- SSH access confirmed to both VMs as `dune@<IP>`
 
-## Next Prompt
-Proceed to `r740xd/02-game-servers.md` to initialize both battlegroups.
+## When This Prompt Is Done
+Tell the user to proceed to `r740xd/02-game-servers.md` to initialize
+both battlegroups.
 
 ## Rollback
-At this stage, nothing on the gaming PC has been touched. To abort:
+At this stage, nothing on the gaming PC has been touched. To abort, run:
 1. `qm stop 101 && qm destroy 101` on the Proxmox host
 2. `qm stop 102 && qm destroy 102` on the Proxmox host
 3. All ISO files and the Proxmox install itself remain intact
+</content>

--- a/prompts/r740xd/02-game-servers.md
+++ b/prompts/r740xd/02-game-servers.md
@@ -1,26 +1,30 @@
 # R740XD-02: Game Server Initialization
 
-This prompt is run FROM your dev machine (all steps are `ssh` commands)
-and targets both VMs — everything it changes lands on the R740's VMs, not
-your dev machine itself. It initializes both battlegroups, configures map
-topology, imports the Dev database backup from the gaming PC, and applies
-the hardening checklist.
+You are an LLM coding agent running in your own session, driving SSH
+commands from wherever this session executes, but every change lands on
+the R740's VMs, not the machine you're typing from. Your job in this
+session: initialize both battlegroups, configure map topology, import
+the Dev database backup from the gaming PC, and apply the hardening
+checklist.
 
 ## Target Machines
-- dune-dev VM (dune@192.168.21.10) — initialized FIRST with backup import
+- dune-dev VM (dune@192.168.21.10) — initialize FIRST, with backup import
 - dune-prod VM (dune@192.168.20.10) — clean battlegroup init SECOND
 
-## Pre-Requisites
+## Before You Start, Confirm
 - `r740xd/01-proxmox-and-vms.md` completed — both VMs have Docker +
-  `dune-awakening-selfhost-docker` cloned
+  `dune-awakening-selfhost-docker` cloned; verify directly rather than
+  assuming if you have no evidence from this session
 - `tabr-tau/00-prerequisites.md` completed — Funcom tokens generated,
   values.env filled
 - For Dev: gaming PC backup transferred per `scripts/06-pre-migration-backup.sh`
 - Read `scripts/04-init-dev-battlegroup.sh` and `scripts/05-init-prod-battlegroup.sh`
+  before running them, so you understand what each interactive prompt
+  expects
 
 ## Phase 1: Transfer Backup to Dev VM
 
-If you haven't already transferred the gaming PC backup:
+If the gaming PC backup hasn't already been transferred, run:
 ```bash
 scp /tmp/opencode/dune-migration-final/*.backup \
   dune@192.168.21.10:~/dune-awakening-selfhost-docker/runtime/backups/db/
@@ -28,11 +32,13 @@ scp /tmp/opencode/dune-migration-final/*.sha256 \
   dune@192.168.21.10:~/dune-awakening-selfhost-docker/runtime/backups/db/
 ```
 
-**VERIFY** checksum on the Dev VM matches:
+Verify the checksum on the Dev VM matches before proceeding:
 ```bash
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker/runtime/backups/db && sha256sum -c *.sha256"
 ```
-All checksums must report "OK".
+All checksums must report "OK". If any fail, stop and do not import —
+report the failure to the user rather than proceeding with a possibly
+corrupt backup.
 
 ## Phase 2: Initialize Dev Battlegroup (WITH backup import)
 
@@ -41,11 +47,11 @@ All checksums must report "OK".
 ssh -t dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && sudo ./install.sh || true && runtime/scripts/dune init"
 ```
 
-Follow the interactive prompts:
+This is interactive. When it prompts, supply or have the user supply:
 - **Server title:** `Tabr Tau - Dev`
-- **Region:** Your region
+- **Region:** the user's usual region
 - **Hosting mode:** Option 2 — Local/LAN (Dev has NO WAN port forwards)
-- **Funcom token:** Paste account #2's token
+- **Funcom token:** account #2's token
 
 ### 2.2 Import the Gaming PC Backup
 ```bash
@@ -57,13 +63,16 @@ DUNE_DB_ASSUME_YES=1 runtime/scripts/dune db import "$(basename $BACKUP)"
 ENDSSH
 ```
 
-**VERIFY:**
+Confirm afterward:
 ```bash
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune sietches validate && runtime/scripts/dune status && runtime/scripts/dune db health"
 ```
+Report the actual output of all three commands — do not report this
+phase complete unless `sietches validate`, `status`, and `db health` all
+report healthy.
 
 ### 2.3 Test 4 Deep Desert Instances on Dev (C-11 fix — mechanical gate)
-This validates the 4-DD configuration BEFORE it reaches Prod:
+This validates the 4-DD configuration BEFORE it reaches Prod. Run:
 
 ```bash
 ssh dune@192.168.21.10 << 'ENDSSH'
@@ -93,9 +102,10 @@ ssh dune@192.168.21.10 "docker ps --format '{{.Names}} {{.Status}}' | grep deepd
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune status > /tmp/dd4-validation-$(date +%Y%m%d).txt"
 ```
 
-**If 4 DD fails on Dev (crashes, OOM, instability):** reduce to 2-3 instances
-and adjust Prod accordingly. Document the actual validated count in the
-day-of runbook.
+**If 4 DD fails on Dev** (crashes, OOM, instability): reduce to 2-3
+instances and adjust the Prod plan accordingly in Phase 3.3 below.
+Document the actual validated count you use, and report it explicitly to
+the user rather than silently substituting a different number.
 
 ## Phase 3: Initialize Prod Battlegroup (CLEAN, no import)
 
@@ -104,11 +114,11 @@ day-of runbook.
 ssh -t dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && sudo ./install.sh || true && runtime/scripts/dune init"
 ```
 
-Follow the interactive prompts:
-- **Server title:** `Tabr Tau`
-- **Region:** Your region
+Interactive prompts — supply or have the user supply:
+- **Server title:** `Tabr Tau` (no "- Dev" suffix — this is Prod)
+- **Region:** the user's usual region
 - **Hosting mode:** Option 1 — Public (uses WAN port forwards)
-- **Funcom token:** Paste account #1's token
+- **Funcom token:** account #1's token
 
 ### 3.2 Configure Sietch Topology (2 dimensions)
 ```bash
@@ -128,7 +138,9 @@ runtime/scripts/dune sietches set-active DeepDesert_1 4
 ENDSSH
 ```
 
-**If Dev validation failed**, use the validated count instead (e.g., `set-max DeepDesert_1 2`).
+If Dev validation failed in Phase 2.3, use the validated count instead
+(e.g., `set-max DeepDesert_1 2`) — do not default to 4 just because it's
+what the doc originally said.
 
 ### 3.4 Configure Hub Cities as Always-On
 ```bash
@@ -151,20 +163,23 @@ runtime/scripts/dune ports
 ENDSSH
 ```
 
-**VERIFY:** `dune ports` must show no WARN lines about advertised vs bound
-IP mismatches. Server IP must match your public IP.
+Confirm `dune ports` shows no WARN lines about advertised vs bound IP
+mismatches, and that the server IP matches the public IP — report the
+actual output, not just "looks fine".
 
-Check container count matches expected:
+Confirm the container count matches expectation:
 - 2 Survival_1 dimensions = 2 containers
-- 4 DeepDesert_1 = 4 containers  
+- 4 DeepDesert_1 (or validated count) = N containers
 - Overmap = 1
 - Director + Gateway + Autoscaler + TextRouter = 4
 - Postgres + RabbitMQ × 2 = 3
-- Total: ~14 containers
+- Total: ~14 containers (with 4 DD)
 
 ```bash
 ssh dune@192.168.20.10 "docker ps --format '{{.Names}}' | wc -l"
 ```
+Report the actual count and whether it matches expectation, and
+investigate any mismatch before proceeding.
 
 ## Phase 4: Apply Hardening Checklist
 
@@ -195,7 +210,9 @@ runtime/scripts/dune db health
 ENDSSH
 ```
 
-Repeat for dune-dev with a DIFFERENT password.
+Repeat the same for dune-dev, generating a DIFFERENT password — never
+reuse the Prod password on Dev. Confirm `dune db health` reports healthy
+on both after rotation before moving on.
 
 ### 4.2 Set Strong Admin Passwords
 ```bash
@@ -203,26 +220,28 @@ Repeat for dune-dev with a DIFFERENT password.
 ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && ADMIN_PASS=\$(openssl rand -base64 24) && echo \"ADMIN_PASSWORD=\${ADMIN_PASS}\" >> .env"
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && ADMIN_PASS=\$(openssl rand -base64 24) && echo \"ADMIN_PASSWORD=\${ADMIN_PASS}\" >> .env"
 ```
+Tell the user to record both new passwords in their password manager —
+never print the generated values back into chat.
 
 ### 4.3 Enable Restart Schedule
 ```bash
-ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune restart-schedule enable 04:00 15"  
-ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune restart-schedule enable 04:00 15"  
+ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune restart-schedule enable 04:00 15"
+ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune restart-schedule enable 04:00 15"
 ```
 
 ### 4.4 Enable DB Auto-Backup
 ```bash
-ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune db auto enable"  
-ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune db auto enable"  
+ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune db auto enable"
+ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune db auto enable"
 ```
 
 ### 4.5 Enable Auto-Update
 
-Applies self-host-kit updates automatically on a schedule rather than
-relying on someone remembering to run `dune update install latest`
+This applies self-host-kit updates automatically on a schedule rather
+than relying on someone remembering to run `dune update install latest`
 manually. Review the kit's own changelog/release notes before enabling
-this on Prod if you'd rather review updates before they apply — `apply 0`
-below only notifies without actually installing, `apply 1` installs.
+this on Prod if the user would rather review updates before they apply —
+`apply 0` below only notifies without installing; `apply 1` installs.
 
 ```bash
 # enable [interval-minutes] [apply 0|1] [notify 0|1] [notify-minutes] [wait-empty 0|1] [max-wait-minutes]
@@ -232,23 +251,26 @@ below only notifies without actually installing, `apply 1` installs.
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune update auto enable 60 1 1 15 0 360"
 
 # Prod: notify only, don't auto-apply -- review updates before they land
-# on the live battlegroup (adjust to 'apply 1' later once you're
-# comfortable trusting unattended updates on Prod specifically)
+# on the live battlegroup (only change to 'apply 1' if the user
+# explicitly asks for unattended updates on Prod specifically)
 ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune update auto enable 60 0 1 15 0 360"
 ```
 
-**VERIFY:**
+Confirm on both VMs:
 ```bash
 ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune update auto status"
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune update auto status"
 ```
+Report the actual status output for both — confirm Dev shows auto-apply
+enabled and Prod shows notify-only, unless the user explicitly asked for
+something different.
 
 ### 4.6 Enable IP-Change-Restart
 
 This project's own findings register already flags "single static IPv4
-with no failover" (L-7) as an accepted risk -- this doesn't fix that, but
-it does make sure that if your ISP ever *does* rotate your public IP
-(common on non-business tiers even with a "static" plan), the game server
+with no failover" (L-7) as an accepted risk — this doesn't fix that, but
+it does make sure that if the ISP ever does rotate the public IP (common
+on non-business tiers even with a "static" plan), the game server
 restarts and re-advertises the new IP to FLS automatically instead of
 silently becoming unreachable until someone notices.
 
@@ -257,30 +279,39 @@ ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/d
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune ip-change-restart enable"
 ```
 
-**VERIFY:**
+Confirm:
 ```bash
 ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune ip-change-restart status"
 ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune ip-change-restart status"
 ```
+Report the actual status for both.
 
-## State After Completion
-- [ ] Dev battlegroup: initialized, backup imported, Sietch validates, DB healthy
-- [ ] 4 Deep Desert instances validated on Dev (mechanical gate C-11 fixed)
-- [ ] Prod battlegroup: initialized clean, 2 Sietch configured
-- [ ] Prod Deep Desert: 4 instances (or validated count if Dev failed)
-- [ ] Hub cities: Arrakeen + Harko Village set to always-on
-- [ ] DB password rotated on both VMs (different passwords, C-3 fix)
-- [ ] Strong admin passwords set on both VMs
-- [ ] Restart schedules enabled (6-hourly)
-- [ ] DB auto-backup enabled on both VMs
-- [ ] Auto-update enabled on both VMs (Dev auto-applies, Prod notify-only
-      by default — adjust once comfortable trusting unattended Prod updates)
-- [ ] IP-change-restart enabled on both VMs
-- [ ] `dune ports` clean — no IP mismatch warnings
+## What to Report Back When This Prompt Is Done
+Confirm and explicitly report each of the following, not just "looks
+done":
+- Dev battlegroup: initialized, backup imported, Sietch validates, DB
+  healthy
+- 4 Deep Desert instances validated on Dev (or the actually-validated
+  count, if different — state which)
+- Prod battlegroup: initialized clean, 2 Sietch configured
+- Prod Deep Desert: 4 instances (or the validated count if Dev's
+  validation failed — state which)
+- Hub cities: Arrakeen + Harko Village set to always-on
+- DB password rotated on both VMs (confirm they are actually different
+  passwords, not the same value copied twice)
+- Strong admin passwords set on both VMs
+- Restart schedules enabled (6-hourly)
+- DB auto-backup enabled on both VMs
+- Auto-update enabled on both VMs (Dev auto-applies, Prod notify-only —
+  state explicitly if this deployment used a different setting)
+- IP-change-restart enabled on both VMs
+- `dune ports` clean on Prod — no IP mismatch warnings
 
-## Next Prompt
-Proceed to `r740xd/03-bot-deploy-and-tunnel.md`, which rotates the ACP
-bot's secrets, deploys the bot, configures the Cloudflare Tunnel, and
-hardens the services — all in the same R740xd session (see issue #59:
-secret rotation moved out of a separate `tabr-tau/01` prompt since it's
-R740-side configuration work, not dev-machine gathering).
+## When This Prompt Is Done
+Tell the user to proceed to `r740xd/03-bot-deploy-and-tunnel.md`, which
+rotates the ACP bot's secrets, deploys the bot, configures the
+Cloudflare Tunnel, and hardens the services — all in its own new R740xd
+session (see issue #59: secret rotation was moved out of a separate
+`tabr-tau/01` prompt since it's R740-side configuration work, not
+dev-machine gathering).
+</content>

--- a/prompts/r740xd/03-bot-deploy-and-tunnel.md
+++ b/prompts/r740xd/03-bot-deploy-and-tunnel.md
@@ -1,29 +1,30 @@
 # R740XD-03: ACP Bot Deployment + Cloudflare Tunnel
 
-This prompt runs in its own session, executed FROM your dev machine's
-terminal via `ssh`/`scp` (there's no separate "log into the console and
-type these" step), but every actual change it makes lands ON the
-dune-prod VM (`192.168.20.10`) — this is R740xd-side configuration work,
-not a Tabr-Tau gathering step, regardless of which physical keyboard
-you're typing on (see issue #59's session boundary). It rotates the
-bot's secrets off the values transferred from OCI, clones and deploys
-the bot, configures the Cloudflare Tunnel, applies security hardening,
-and runs end-to-end verification.
+You are an LLM coding agent running in your own session, executed from
+the dev machine's terminal via `ssh`/`scp` (there's no separate "log into
+the console and type these" step), but every actual change you make
+lands ON the dune-prod VM (`192.168.20.10`) — this is R740xd-side
+configuration work, not a Tabr-Tau gathering step, regardless of which
+physical keyboard you're typing on (see issue #59's session boundary).
+Your job in this session: rotate the bot's secrets off the values
+transferred from OCI, clone and deploy the bot, configure the Cloudflare
+Tunnel, apply security hardening, and run end-to-end verification.
 
 ## Target Machines
 - dune-prod VM (`dune@192.168.20.10`) — everything below changes state here
-- Your dev machine — only used as the SSH client; also needed for the
-  Discord Developer Portal and Cloudflare Zero Trust dashboard
-  (browser-based, Phase 1 and Phase 3.2)
+- The dev machine — only used as the SSH client; the user will also need
+  browser access to the Discord Developer Portal and Cloudflare Zero
+  Trust dashboard (Phase 1 and Phase 3.2) — you cannot drive those
+  browser steps yourself, walk the user through them.
 
-## Pre-Requisites
+## Before You Start, Confirm
 - `r740xd/02-game-servers.md` completed — both battlegroups initialized
 - `tabr-tau/00-prerequisites.md` completed — bot secrets staged locally
   to `~/r740-bot-backup/secrets/`, Discord/Funcom credentials ready in
-  your password manager (that prompt only gathers/stages; it does not
-  rotate or deploy anything)
-- Discord Developer Portal accessible in your browser (Phase 1)
-- Cloudflare Zero Trust dashboard accessible in your browser (Phase 3.2)
+  the user's password manager (that prompt only gathers/stages; it does
+  not rotate or deploy anything — do not assume it did)
+- The user has Discord Developer Portal access ready (Phase 1)
+- The user has Cloudflare Zero Trust dashboard access ready (Phase 3.2)
 
 ## Phase 1: Rotate Secrets Migrated from OCI (C-6 fix)
 
@@ -31,28 +32,31 @@ The bot token/secrets staged in `~/r740-bot-backup/secrets/` (from
 `tabr-tau/00-prerequisites.md`) were copied from the still-live OCI
 instance. They must never be the ones actually used going forward — the
 old host, or backups of it, could retain access to them indefinitely.
-Rotate BEFORE cloning/deploying the bot below, not after.
+Rotate BEFORE cloning/deploying the bot below, not after — do not skip
+ahead to Phase 2 with the OCI-origin secrets still in play.
 
 ### 1.1 Rotate Discord Bot Token
-1. Discord Developer Portal → Your Application → Bot → **Reset Token**
-2. Copy the new token string — you'll use it in Phase 2's `.env` setup
-   below, not written anywhere yet.
+Ask the user to:
+1. Go to Discord Developer Portal → Your Application → Bot → **Reset Token**
+2. Give you the new token string — you'll use it in Phase 2's `.env`
+   setup below. Do not write it anywhere yet.
 
 ### 1.2 Rotate Discord OAuth Client Secret (CLOUD-03 fix)
-If multi-tenant mode uses `DISCORD_CLIENT_SECRET`:
-1. Discord Developer Portal → OAuth2 → **Reset Client Secret**
-2. Copy the new secret — same as above, used in Phase 2.
+If multi-tenant mode uses `DISCORD_CLIENT_SECRET`, ask the user to:
+1. Go to Discord Developer Portal → OAuth2 → **Reset Client Secret**
+2. Give you the new secret — same as above, used in Phase 2.
 
-### 1.3 Shred the Staged Secrets Backup (on your dev machine)
-Once you've copied the values you need from
+### 1.3 Shred the Staged Secrets Backup (on the dev machine)
+Once you've used the values you need from
 `~/r740-bot-backup/secrets/bot-env.txt` for Phase 2 below, shred the
-local staging copy — it should not persist once its values are in use:
+local staging copy — it must not persist once its values are in use:
 ```bash
-# On your dev machine:
+# On the dev machine:
 shred -u ~/r740-bot-backup/secrets/bot-env.txt
 shred -u ~/r740-bot-backup/secrets/acp.db
 rm -rf ~/r740-bot-backup/secrets/
 ```
+Confirm the directory no longer exists after running this.
 
 ## Phase 2: Clone and Deploy the Bot
 
@@ -64,7 +68,7 @@ cd ~/arrakis-control-panel
 npm ci --omit=dev
 cp .env.example .env
 
-# Set the essential values (update with your real values)
+# Set the essential values (update with the real values)
 sed -i "s|^DUNE_CONSOLE_API_URL=.*|DUNE_CONSOLE_API_URL=http://localhost:8088|" .env
 # DISCORD_BOT_TOKEN: use the ROTATED value from Phase 1.1 above, NOT the
 #   original value staged from OCI in tabr-tau/00-prerequisites.md
@@ -75,6 +79,8 @@ sed -i "s|^DUNE_CONSOLE_API_URL=.*|DUNE_CONSOLE_API_URL=http://localhost:8088|" 
 # DUNE_DISCORD_ADAPTER_TOKEN: from tabr-tau/00-prerequisites.md
 ENDSSH
 ```
+Set each `.env` value using the rotated secrets from Phase 1, not the
+original OCI-origin values — double-check this before moving on.
 
 ### 2.2 Generate ACP_SECRETS_KEY (CLOUD-08 fix, if multi-tenant)
 If `ACP_MULTI_TENANT=true`, per-guild adapter tokens in the SQLite
@@ -88,24 +94,26 @@ echo "ACP_SECRETS_KEY generated. Existing plaintext tokens in acp.db will"
 echo "need re-provisioning via the setup portal."
 ENDSSH
 ```
+Tell the user existing plaintext tokens will need re-provisioning via
+the setup portal after this change.
 
 ### 2.3 Register Slash Commands
 ```bash
 ssh dune@192.168.20.10 "cd ~/arrakis-control-panel && npm run register"
 ```
-
-**VERIFY:** The command output shows registration success with no errors.
+Confirm the command output shows registration success with no errors —
+report the actual output, don't assume success.
 
 ### 2.4 (Optional) Install Local Pre-Commit Hooks
 
-**Only needed if you plan to edit the bot's code directly on this VM**
-(debugging, quick fixes) rather than exclusively pushing from your dev
+Only do this if the user plans to edit the bot's code directly on this
+VM (debugging, quick fixes) rather than exclusively pushing from the dev
 machine via `git push deploy` (the intended workflow — see Phase 6). The
 bot repo already ships its own `.pre-commit-config.yaml`
-(gitleaks/ggshield/trivy) that travels with the clone; this just activates
-it locally so a direct commit on this VM gets the same scan coverage your
-dev machine's commits already get, rather than only catching issues later
-in CI:
+(gitleaks/ggshield/trivy) that travels with the clone; this just
+activates it locally so a direct commit on this VM gets the same scan
+coverage the dev machine's commits already get, rather than only
+catching issues later in CI:
 
 ```bash
 ssh dune@192.168.20.10 << 'ENDSSH'
@@ -116,7 +124,8 @@ ENDSSH
 ```
 
 Skip this step entirely if this VM will only ever receive deploys via
-`git push deploy` and no one edits code on it directly.
+`git push deploy` and no one edits code on it directly — ask the user if
+unsure rather than running it unconditionally.
 
 ### 2.5 Install and Enable Systemd Service
 ```bash
@@ -129,11 +138,13 @@ sudo systemctl status acp-bot.service
 ENDSSH
 ```
 
-**VERIFY:** `systemctl status` shows `active (running)`. Check logs:
+Confirm `systemctl status` shows `active (running)`. Check logs:
 ```bash
 ssh dune@192.168.20.10 "journalctl -u acp-bot -n 30 --no-pager"
 ```
-The bot should show "Ready!" and connect to Discord's gateway.
+Confirm the bot shows "Ready!" and connects to Discord's gateway — report
+the actual log lines, don't just assume it worked because the service
+"started".
 
 ## Phase 3: Configure Cloudflare Tunnel
 
@@ -165,44 +176,49 @@ ingress:
 **Coordinate this change carefully**: the same Cloudflare account's
 tunnel/DDNS infrastructure is shared with other independent services
 (e.g. the ACP landing page and other sites using the same Cloudflare DDNS
-setup) — verify you are only adding new ingress rules for these
-hostnames, not modifying shared tunnel config that other services depend
-on.
+setup). Before editing, confirm you are only adding new ingress rules for
+these hostnames, not modifying shared tunnel config that other services
+depend on — read the existing file first, don't overwrite it wholesale.
 
 Restart the tunnel:
 ```bash
 ssh dune@192.168.20.10 "sudo systemctl restart cloudflared && sudo systemctl status cloudflared"
 ```
 This restarts the ENTIRE tunnel daemon, not just these ingress rules —
-confirm current status of every hostname/service sharing this tunnel
-before restarting, per this project's own Requirement 23 on documenting
-network ingress points.
+before restarting, confirm current status of every hostname/service
+sharing this tunnel and, per this project's Requirement 23 on documenting
+network ingress points, make sure the new ingress point ends up
+documented afterward.
 
 ### 3.2 Enforce Cloudflare Access (C-8 — was "recommended", now MANDATORY)
 
 **This step is NOT optional.** Without it, anyone who discovers the
 hostname can reach the admin console login page. The console mounts the
-Docker socket — reaching that page is one password away from root-equivalent
-VM access.
+Docker socket — reaching that page is one password away from
+root-equivalent VM access. Do not report this phase complete without it.
 
+Walk the user through (you cannot drive the Cloudflare dashboard
+yourself):
 1. Cloudflare Zero Trust Dashboard → Access → Applications → **Add Application**
 2. Type: **Self-hosted**
 3. Application name: `Dune Console`
 4. Subdomain: `CONSOLE_TUNNEL_HOSTNAME`
-5. Identity providers: Accept all (or add your email provider)
+5. Identity providers: Accept all (or add the user's email provider)
 6. **Create policy:**
    - Policy name: `Admin Only`
    - Action: **Allow**
-   - Include → Emails → `your-email@example.com`
-   - (Add any additional trusted operators)
+   - Include → Emails → the user's email
+   - (Add any additional trusted operators the user specifies)
 7. Save policy → **repeat for `ACP_SETUP_TUNNEL_HOSTNAME`** (at minimum,
    protect the `/auth/steam` path)
 8. Save and close
 
-**VERIFY:** Open an incognito/private browser window and navigate to
-`https://CONSOLE_TUNNEL_HOSTNAME`. You MUST see a Cloudflare Access login
-page (email/PIN prompt) BEFORE reaching the Dune Console login. If you
-see the console login directly, Access is NOT configured.
+Ask the user to open an incognito/private browser window and navigate to
+`https://CONSOLE_TUNNEL_HOSTNAME`, and report back what they see. They
+MUST see a Cloudflare Access login page (email/PIN prompt) BEFORE
+reaching the Dune Console login. If they report seeing the console login
+directly, Access is NOT configured — treat this as a blocking failure
+and go back to step 1 above.
 
 ## Phase 4: Configure Database Backup (C-4 fix)
 
@@ -247,16 +263,17 @@ sudo systemctl start acp-db-backup.service
 ENDSSH
 ```
 
-**VERIFY:**
+Confirm:
 ```bash
 ssh dune@192.168.20.10 "ls -la ~/arrakis-control-panel/data/backups/ && systemctl list-timers acp-db-backup.timer"
 ```
+Report the actual backup file listing and timer status.
 
 ## Phase 5: End-to-End Verification
 
 ### 5.1 Discord Bot Smoke Test
-Run `/dune server health` in your Discord server. The bot must respond
-with server status within 5 seconds.
+Ask the user to run `/dune server health` in their Discord server and
+report whether the bot responds with server status within 5 seconds.
 
 ### 5.2 Adapter Endpoint Verification
 ```bash
@@ -267,25 +284,28 @@ curl -s -H "Authorization: Bearer ${ADAPTER_TOKEN}" \
   http://localhost:8088/api/integrations/discord/health | jq .
 ENDSSH
 ```
-Expected: `{"ok": true, ...}`
+Expected: `{"ok": true, ...}`. Report the actual response and flag any
+deviation.
 
 ### 5.3 Cloudflare Tunnel Verification
 ```bash
-# From your dev machine:
+# From the dev machine:
 curl -s https://ACP_SETUP_TUNNEL_HOSTNAME/api/live-stats | jq .players_online
 curl -s -o /dev/null -w '%{http_code}' https://CONSOLE_TUNNEL_HOSTNAME
 ```
-Expected: live stats returns JSON with a `players_online` field.
-Console returns `302` or `200` (redirect to Access login is OK).
+Expected: live stats returns JSON with a `players_online` field. Console
+returns `302` or `200` (redirect to Access login is OK). Report actual
+results.
 
 ### 5.4 Firewall Isolation Verification
 From dune-dev VM, confirm Prod is unreachable:
 ```bash
 ssh dune@192.168.21.10 "ping -c 3 -W 2 192.168.20.10; echo EXIT=\$?"
 ```
-Expected: ping fails (non-zero exit). If it succeeds, VLAN isolation is
-broken — go back to Phase 2.0 of `r740xd/01-proxmox-and-vms.md` and fix
-`bridge-vlan-aware`.
+Expected: ping fails (non-zero exit). **If it succeeds, VLAN isolation
+is broken — stop, report this to the user, and go back to Phase 2.0 of
+`r740xd/01-proxmox-and-vms.md` to fix `bridge-vlan-aware` before
+continuing this prompt.**
 
 ## Phase 6: Deploy Remote Setup (for future git push deploys)
 
@@ -296,29 +316,34 @@ cp ~/arrakis-control-panel/scripts/deploy-post-receive.sh hooks/post-receive
 chmod +x hooks/post-receive
 ENDSSH
 
-# On your dev machine, add the deploy remote:
+# On the dev machine, add the deploy remote:
 git -C ~/projects/acp/arrakis-control-panel remote add deploy \
   ssh://dune@192.168.20.10/home/dune/acp-deploy.git
 ```
 
-## State After Completion
-- [ ] Discord bot token rotated (C-6)
-- [ ] OAuth client secret rotated if multi-tenant (CLOUD-03)
-- [ ] Staged secrets backup shredded on dev machine
-- [ ] ACP_SECRETS_KEY generated if multi-tenant (CLOUD-08)
-- [ ] ACP bot cloned, installed, running on dune-prod VM
-- [ ] Systemd service `acp-bot.service` active and enabled
-- [ ] Cloudflare Tunnel ingress rules configured (incl. Steam port 3101)
-- [ ] Cloudflare Access MANDATORY policy in front of CONSOLE_TUNNEL_HOSTNAME
-- [ ] SQLite daily backup timer created and active (C-4)
-- [ ] Bot responds to slash commands in Discord
-- [ ] All adapter endpoints verified
-- [ ] VLAN isolation verified
-- [ ] Deploy remote configured
+## What to Report Back When This Prompt Is Done
+Confirm and explicitly report each of the following, not just "looks
+done":
+- Discord bot token rotated (C-6)
+- OAuth client secret rotated if multi-tenant (CLOUD-03)
+- Staged secrets backup shredded on the dev machine
+- ACP_SECRETS_KEY generated if multi-tenant (CLOUD-08)
+- ACP bot cloned, installed, running on dune-prod VM
+- Systemd service `acp-bot.service` active and enabled
+- Cloudflare Tunnel ingress rules configured (incl. Steam port 3101)
+- Cloudflare Access MANDATORY policy confirmed in front of
+  CONSOLE_TUNNEL_HOSTNAME (confirmed via the user's incognito test, not
+  assumed)
+- SQLite daily backup timer created and active (C-4)
+- Bot responds to slash commands in Discord
+- All adapter endpoints verified
+- VLAN isolation verified (ping from Dev to Prod failed as expected)
+- Deploy remote configured
 
-## After This Prompt Completes
-Start a NEW, separate session on your dev machine and proceed to
-`tabr-tau/04-e2e-verification.md` for the full go-live checklist — that
-prompt's own scope has been narrowed to dev-machine-appropriate checks
-only (running the automated verification script, external WAN/browser
-tests); see issue #59.
+## When This Prompt Is Done
+Tell the user to start a NEW, separate session on the dev machine and
+proceed to `tabr-tau/04-e2e-verification.md` for the full go-live
+checklist — that prompt's scope is narrowed to dev-machine-appropriate
+checks only (running the automated verification script, external
+WAN/browser tests); see issue #59.
+</content>

--- a/prompts/r740xd/04-post-deployment-ops.md
+++ b/prompts/r740xd/04-post-deployment-ops.md
@@ -1,16 +1,17 @@
 # R740XD-04: Post-Deployment Performance Baseline, Monitoring & Troubleshooting
 
-This prompt runs in its own session, executed via SSH against the R740's
-VMs — split out of the former `tabr-tau/04-e2e-verification.md` (issue
-#59) since capturing performance data and troubleshooting commands are
-R740-side operations, not dev-machine gathering, even though you may be
-typing them from your dev machine's terminal.
+You are an LLM coding agent running in your own session, executed via
+SSH against the R740's VMs — split out of the former
+`tabr-tau/04-e2e-verification.md` (issue #59) since capturing
+performance data and troubleshooting commands are R740-side operations,
+not dev-machine gathering, even though you may be typing them from the
+dev machine's terminal.
 
-## Pre-Requisites
+## Before You Start, Confirm
 - `r740xd/01-proxmox-and-vms.md` through `r740xd/03-bot-deploy-and-tunnel.md`
   fully executed
 - `tabr-tau/04-e2e-verification.md`'s automated suite and manual WAN/Discord
-  checks passed
+  checks passed — ask the user to confirm if you have no direct evidence
 
 ## Phase 1: Performance Baseline
 
@@ -26,17 +27,20 @@ uptime
 ENDSSH
 ```
 
-Save this output — it's your baseline for comparing against when players
-are online.
+Save this output and report it back to the user — it's the baseline for
+comparing against when players are online later.
 
 ### 1.2 Monitor During First Player Session
-After players join, re-run the stats command above and compare:
-- Memory usage should remain below 140 GB (92% of 152 GB)
-- No container should show CPU consistently above 80%
-- `dune status` should remain healthy
+After players join, re-run the stats command above and compare against
+the baseline. Flag explicitly if any of the following are true rather
+than reporting a generic "looks fine":
+- Memory usage exceeds 140 GB (92% of 152 GB)
+- Any container shows CPU consistently above 80%
+- `dune status` reports anything other than healthy
 
 ## Phase 2: First 24 Hours Monitoring
 
+Run each of the following and report the actual output:
 ```bash
 # Watch dune status hourly for any warnings:
 ssh dune@192.168.20.10 "cd ~/dune-awakening-selfhost-docker && runtime/scripts/dune status"
@@ -48,10 +52,16 @@ ssh dune@192.168.20.10 "journalctl -u acp-bot -n 50 --no-pager"
 ssh dune@192.168.20.10 "ls -la ~/dune-awakening-selfhost-docker/runtime/backups/db/ | tail -5"
 ```
 
-Also monitor player reports for lag, disconnects, or instability, and
-check Cloudflare Tunnel health (`systemctl status cloudflared` on the VM).
+Also ask the user to report any player-reported lag, disconnects, or
+instability, and check Cloudflare Tunnel health yourself
+(`systemctl status cloudflared` on the VM) rather than assuming it's
+still up because it was earlier.
 
 ## Troubleshooting
+
+Use these if the user reports a problem, or if your own monitoring above
+surfaces one — don't wait to be asked if you've already detected an
+issue.
 
 ### `dune status` shows warnings
 ```bash
@@ -68,7 +78,7 @@ ssh dune@192.168.20.10 "journalctl -u acp-bot --since '10 min ago' --no-pager | 
 
 ### Players can't connect
 ```bash
-# From dev machine, test each port:
+# From the dev machine, test each port:
 nc -zu -w 2 <PUBLIC_IP> 7778
 nc -z -w 2 <PUBLIC_IP> 31982
 
@@ -80,16 +90,21 @@ ssh dune@192.168.20.10 "ss -ulnp | grep '777[7-9]'"
 ```bash
 # Test tunnel health:
 ssh dune@192.168.20.10 "systemctl status cloudflared && cloudflared tunnel info"
-# Verify Access policy in Cloudflare Zero Trust dashboard
+# Verify Access policy in Cloudflare Zero Trust dashboard -- ask the
+# user to check this, you cannot access the dashboard yourself
 ```
 
-## State After Completion
-- [ ] Performance baseline captured
-- [ ] 24-hour monitoring initiated, no unresolved warnings
-- [ ] Daily DB backups confirmed running
+## What to Report Back When This Prompt Is Done
+Confirm and explicitly report each of the following:
+- Performance baseline captured (include the actual numbers)
+- 24-hour monitoring initiated, and whether any warnings remain
+  unresolved
+- Daily DB backups confirmed running (include the actual file listing)
 
-## After This Prompt Completes
-Once burn-in (a few days of stable production with real players) is
-complete, start a Tabr-Tau session for the final evidence/decommission
-steps in `tabr-tau/04-e2e-verification.md`'s Phase 6 and
-`scripts/07-wsl-decommission.sh` on the gaming PC.
+## When This Prompt Is Done
+Tell the user that once burn-in (a few days of stable production with
+real players) is complete, they should start a Tabr-Tau session for the
+final evidence/decommission steps in `tabr-tau/04-e2e-verification.md`'s
+Phase 6 and `scripts/07-wsl-decommission.sh` on the gaming PC. Do not
+run the decommission script yourself in this session.
+</content>

--- a/prompts/tabr-tau/00-prerequisites.md
+++ b/prompts/tabr-tau/00-prerequisites.md
@@ -1,67 +1,88 @@
 # TABR-TAU-00: Prerequisites — Gather Before Racking Hardware
 
-**Scope note (2026-08-14):** this prompt runs in its own, separate
-session on YOUR DEV MACHINE and is strictly limited to gathering
-credentials, tokens, and configuration values — nothing that installs,
-configures, or connects to R740-side infrastructure. All installation
-and configuration work (ISO acquisition, Proxmox install, VM
-provisioning, bot deployment) happens exclusively in `r740xd/*` prompts,
-run in their own separate session, on/against the R740 itself. If a step
-here ever needs to SSH into a VM or the Proxmox host, that step belongs
-in `r740xd/`, not here — see issue #59 for the audit that established
-this boundary and moved several misplaced steps out of this file.
+You are an LLM coding agent running in your own, separate session on the
+user's DEV MACHINE (Tabr-Tau). Your scope in this session is gathering
+only: collect credentials, tokens, and configuration values, and verify
+their presence/permissions. Do not install, configure, or connect to
+any R740-side infrastructure (Proxmox host or either VM) in this
+session — that work belongs exclusively to the `r740xd/*` prompts, which
+run in their own separate sessions, targeting the R740 itself. If any
+step in this file ever appears to require SSH-ing into a VM or the
+Proxmox host, stop and tell the user that step belongs in `r740xd/`
+instead — see issue #59 for the audit that established this boundary and
+moved several misplaced steps out of this file. Never weaken this
+boundary just because it would be technically possible to reach the R740
+from this machine.
 
-**Status on this deployment (2026-08-14):** Steps 1 and 3 verified
-read-only, directly on the Tabr-Tau dev machine this prompt targets (the
-R740xd-side session has no access to this host's filesystem, SSH keys, or
-network vantage point to run these checks itself). See issue #57 for the
-full verification record.
+**Status on this deployment (2026-08-14):** Steps 1 and 3 have already
+been verified read-only, directly on this dev machine (a prior R740xd
+session has no access to this host's filesystem, SSH keys, or network
+vantage point to run these checks itself). See issue #57 for the full
+verification record. Re-verify rather than assume these are still true
+if meaningful time has passed or the environment may have changed.
 
 ## Target Machine
-Your current dev machine (Ubuntu 24.04).
+Your current dev machine (Ubuntu 26.04). Do not target anything else.
 
-## Pre-Requisites
-- You have a password manager with the following stored (or will generate
-  them during this prompt):
-  - 2× Funcom Self-Host Service Tokens (accounts #1 and #2)
-  - Discord bot token for the ACP bot
-  - Discord application client ID
-  - GitHub personal access token (for cloning private repos if needed)
+## Before You Start
+Confirm the user has, or is ready to generate during this session:
+- 2× Funcom Self-Host Service Tokens (accounts #1 and #2)
+- Discord bot token for the ACP bot
+- Discord application client ID
+- GitHub personal access token (for cloning private repos if needed)
+
+Ask the user for any of these you don't already have, rather than
+guessing or leaving a placeholder unfilled.
 
 ## Steps
 
 ### 1. Verify Required Files Exist
+Run:
 ```bash
 ls ~/projects/dune/dune-awakening-selfhost-docker/runtime/scripts/dune
 ls ~/projects/acp/arrakis-control-panel/package.json
 ls ~/r740-deployment/prompts/tabr-tau/00-prerequisites.md
 ```
+Report back which paths exist and which don't. If any are missing, stop
+and ask the user how they want to proceed rather than assuming an
+alternate path.
+
 **Verified 2026-08-14:** all three paths present on the Tabr-Tau dev
 machine.
 
 ### 2. Verify SSH Keys
+Run:
 ```bash
 # The SSH key used for deploy remote (issue #81)
 ls -la ~/.ssh/ssh-key-2026-07-18.key
 chmod 600 ~/.ssh/ssh-key-2026-07-18.key
 ```
+Confirm the permissions are `600` after running this. Report the result.
+
 **Verified 2026-08-14:** already `600`, no change needed.
 
 ### 3. Gather Network Values
-Fill in `r740-deployment/docs/values.env.example` with your actual values.
-Copy it to a gitignored file:
+Fill in `r740-deployment/docs/values.env.example` with the user's actual
+values. Copy it to a gitignored file first — never edit the `.example`
+file itself with real values:
 
 ```bash
 cp ~/r740-deployment/docs/values.env.example ~/r740-deployment/docs/values.env
-# Edit values.env with your real public IP, server names, region
+# Edit values.env with the real public IP, server names, region
 ```
 
-Complete this checklist:
-- [ ] `PUBLIC_IP=` filled in (use `curl -s https://api.ipify.org` from the gaming PC or router)
-- [ ] `SERVER_TITLE_PROD=` set (e.g., "Tabr Tau")
-- [ ] `SERVER_TITLE_DEV=` set (e.g., "Tabr Tau - Dev")
-- [ ] `SERVER_REGION=` set
-- [ ] Funcom tokens noted (which account goes to which VM)
+Populate and confirm each of the following, asking the user for any
+value you cannot determine yourself:
+- `PUBLIC_IP=` (determine via `curl -s https://api.ipify.org` run from
+  the gaming PC or router, not from this dev machine if it's on a
+  different network)
+- `SERVER_TITLE_PROD=` (e.g., "Tabr Tau")
+- `SERVER_TITLE_DEV=` (e.g., "Tabr Tau - Dev")
+- `SERVER_REGION=`
+- Funcom tokens noted (which account goes to which VM)
+
+Report which of these are filled in and which still need the user's
+input. Never invent a placeholder value and present it as real.
 
 **Verified 2026-08-14 (partial):** current public IP confirmed via
 `curl https://api.ipify.org` — matches the IP already live in the
@@ -71,28 +92,26 @@ state — nothing to leak).
 
 ### 4. Prepare ACP Bot Secrets Backup (gathering only — do not act on migration timing)
 
-**This step describes gathering secrets for a FUTURE, not-yet-scheduled
-bot migration.** The ACP bot is a live, currently-running production
-service on its existing OCI VPS as of this writing — the actual
-migration (stopping the OCI bot, deploying to dune-prod, rotating
-secrets) is R740-side work that happens entirely in
-`r740xd/03-bot-deploy-and-tunnel.md`'s own Phase 1, not here. This step
-only stages a
-local backup bundle on your dev machine so those later steps have
-something to work from — it does not SSH into or configure `dune-prod`.
-`OCI_BOT_IP` below is a placeholder — substitute your own real value
-from your password manager/infra notes when actually executing this.
+This step gathers secrets for a FUTURE, not-yet-scheduled bot migration.
+The ACP bot is a live, currently-running production service on its
+existing OCI VPS as of this writing — the actual migration (stopping the
+OCI bot, deploying to dune-prod, rotating secrets) is R740-side work that
+happens entirely in `r740xd/03-bot-deploy-and-tunnel.md`'s own Phase 1,
+not here. This step only stages a local backup bundle on this dev
+machine so those later steps have something to work from — it must not
+SSH into or configure `dune-prod`. `OCI_BOT_IP` below is a placeholder —
+ask the user for the real value (from their password manager/infra
+notes) before running these commands; never guess or fabricate it.
 
 ```bash
 mkdir -p ~/r740-bot-backup/secrets
 
-# If you can SSH to the OCI instance (this is the CURRENT production
-# host, not the R740 -- reading its own existing secrets is gathering,
-# not R740-side configuration):
+# Reading the CURRENT production host's (OCI, not the R740) own existing
+# secrets is gathering, not R740-side configuration:
 ssh ubuntu@OCI_BOT_IP "cat ~/arrakis-control-panel/.env" \
   > ~/r740-bot-backup/secrets/bot-env.txt
 
-# NOTE: chmod 600 (not 644) on the remote temp copy -- the SQLite DB
+# Use chmod 600 (not 644) on the remote temp copy -- the SQLite DB
 # contains per-guild adapter tokens; a world-readable temp copy on a
 # shared host is the same class of exposure this project's own #28
 # finding flagged for the local staging directory.
@@ -100,28 +119,33 @@ ssh ubuntu@OCI_BOT_IP "sudo cp ~/arrakis-control-panel/data/acp.db /tmp/ && sudo
   && scp ubuntu@OCI_BOT_IP:/tmp/acp.db ~/r740-bot-backup/secrets/ \
   && ssh ubuntu@OCI_BOT_IP "shred -u /tmp/acp.db"
 
-# Or, if you already have the .env backed up locally:
-# Copy it from your secure backup location to ~/r740-bot-backup/secrets/
-
 chmod 600 ~/r740-bot-backup/secrets/*
 ```
 
-Verify the bot-env.txt contains at minimum:
+Verify `bot-env.txt` contains at minimum the following keys, and report
+which are present/missing (never print the actual secret values back to
+the user in chat):
 - `DISCORD_BOT_TOKEN=`
 - `DISCORD_CLIENT_ID=`
 - `DUNE_CONSOLE_API_URL=` (will be changed to `http://localhost:8088`
   during the actual R740-side deployment, not here)
 - `DUNE_DISCORD_ADAPTER_TOKEN=`
 
-### 5. Final Checklist Before Moving to r740xd/01
-- [ ] `values.env` filled in with real values
-- [x] SSH keys verified (2026-08-14 — already `600`, see Step 2)
-- [ ] 2× Funcom tokens generated and stored in password manager
-- [ ] Bot secrets backup staged to `~/r740-bot-backup/secrets/` (Step 4)
-- [ ] R740 racked, powered, network cabled to UCG-Max
+### 5. Report Final Status Before Moving to r740xd/01
+Report the status of each of the following back to the user as a
+checklist, explicitly marking each item done/not-done:
+- `values.env` filled in with real values
+- SSH keys verified (permissions `600`)
+- 2× Funcom tokens generated and stored in the user's password manager
+- Bot secrets backup staged to `~/r740-bot-backup/secrets/` (Step 4)
+- R740 racked, powered, network cabled to UCG-Max (ask the user to
+  confirm this — you have no way to verify it from this session)
 
-## After This Prompt Completes
-Start a NEW, separate session and proceed to `r740xd/01-proxmox-and-vms.md`,
-which runs ON THE PROXMOX HOST itself. That prompt handles ISO
-acquisition (Proxmox VE + Ubuntu Server), the actual Proxmox install, and
-VM provisioning — none of which belongs in this gathering-only session.
+## When This Prompt Is Done
+Tell the user to start a NEW, separate session and run
+`r740xd/01-proxmox-and-vms.md`, which runs ON THE PROXMOX HOST itself.
+That prompt handles ISO acquisition (Proxmox VE + Ubuntu Server), the
+actual Proxmox install, and VM provisioning — none of which belongs in
+this gathering-only session. Do not attempt any of that work yourself in
+this session even if asked; redirect to the correct prompt/session.
+</content>

--- a/prompts/tabr-tau/04-e2e-verification.md
+++ b/prompts/tabr-tau/04-e2e-verification.md
@@ -1,30 +1,37 @@
 # TABR-TAU-04: End-to-End Verification & Go-Live Cutover
 
-This prompt runs in its own session, ON YOUR DEV MACHINE, after ALL
-R740xd deployment phases are complete
+You are an LLM coding agent running in your own session, ON THE USER'S
+DEV MACHINE, after ALL R740xd deployment phases are complete
 (`r740xd/01-proxmox-and-vms.md` through `r740xd/03-bot-deploy-and-tunnel.md`).
-It runs the full automated verification suite, performs manual checks
-that only make sense from outside the R740's own network (WAN
-reachability, browser-based checks), and walks through the go-live
-announcement.
+Your job in this session: run the full automated verification suite,
+perform manual checks that only make sense from outside the R740's own
+network (WAN reachability, browser-based checks — ask the user to
+perform these and report results back to you, since you cannot browse
+or use a cellular device yourself), and walk the user through the
+go-live announcement.
 
 **Scope note (2026-08-14):** this prompt previously also included
 performance-baseline capture and SSH-based troubleshooting commands —
 those were R740-side operations mistakenly included here and have moved
-to `r740xd/04-post-deployment-ops.md` (issue #59). If you need those,
-start a separate R740xd session for that prompt instead.
+to `r740xd/04-post-deployment-ops.md` (issue #59). If the user asks you
+to do those things in this session, tell them to start a separate
+R740xd session for that prompt instead — do not perform them here even
+if you technically have SSH access.
 
-## Pre-Requisites
+## Before You Start, Confirm
 - `r740xd/01-proxmox-and-vms.md` through `r740xd/03-bot-deploy-and-tunnel.md`
-  fully executed (in their own R740xd session)
-- Both VMs online with game servers running
-- ACP bot deployed and connected to Discord
-- Cloudflare Tunnel configured with Access enforced
-- You have a device outside your LAN (phone on cellular) for WAN testing
+  have actually been fully executed (in their own R740xd sessions) —
+  ask the user to confirm if you have no direct evidence.
+- Both VMs are online with game servers running.
+- ACP bot is deployed and connected to Discord.
+- Cloudflare Tunnel is configured with Access enforced.
+- The user has a device outside their LAN (phone on cellular) available
+  for WAN testing — you cannot perform this test yourself.
 
 ## Phase 1: Run Automated Verification Suite
 
 ### 1.1 Execute the E2E Verification Script
+Run:
 ```bash
 bash ~/r740-deployment/scripts/11-e2e-verify.sh
 ```
@@ -42,50 +49,62 @@ This runs 70+ checks across 11 categories:
 10. Database Integrity (4 checks)
 11. ACP Landing & DNS (2 checks)
 
-### 1.2 Review the Report
-The report is saved to `/tmp/opencode/e2e-report-YYYYMMDD-HHMMSS.txt`.
+### 1.2 Review and Report the Result
+Read the report saved to `/tmp/opencode/e2e-report-YYYYMMDD-HHMMSS.txt`
+and summarize it back to the user, categorized as follows:
 
-**CRITICAL failures (any):** DO NOT GO LIVE. Fix the failing checks before
-proceeding (in a separate R740xd session, if the fix requires touching
-the VMs — this dev-machine session shouldn't apply fixes itself).
-
-**Warnings only:** Review each warning. Warnings about optional hardening
-items (SSH, firewall, metrics) can be addressed post-launch. Warnings about
-game server or network reachability should be investigated.
-
-**All green:** Proceed to Phase 2.
+- **Any CRITICAL failure:** tell the user explicitly not to go live.
+  Identify the failing checks and, if the fix requires touching the
+  VMs, tell the user to start a separate R740xd session to apply it —
+  do not attempt to fix R740-side state from this dev-machine session.
+- **Warnings only:** list each warning. Warnings about optional
+  hardening items (SSH, firewall, metrics) can be deferred past launch
+  if the user accepts that; warnings about game server or network
+  reachability must be investigated before proceeding — do not let
+  these pass silently.
+- **All green:** tell the user you're proceeding to Phase 2.
 
 ## Phase 2: Manual WAN Verification (from outside LAN)
 
+You cannot perform these checks yourself — walk the user through each
+one and ask them to report the result back to you before proceeding.
+
 ### 2.1 Game Ports
-From a device on cellular data (NOT your home WiFi):
-- Open the game and attempt to connect to your server
-- Verify you see the server in the server browser at your public IP
-- Join the server and confirm you can play
+Ask the user, from a device on cellular data (NOT their home WiFi), to:
+- Open the game and attempt to connect to the server
+- Verify the server appears in the server browser at the public IP
+- Join the server and confirm they can play
 
 ### 2.2 Console Access (behind Cloudflare Access)
-From a cellular device or incognito browser:
+Ask the user, from a cellular device or incognito browser, to:
 1. Navigate to `https://CONSOLE_TUNNEL_HOSTNAME`
-2. **Verify you see the Cloudflare Access login page** (email/PIN prompt)
+2. Confirm they see the Cloudflare Access login page (email/PIN prompt)
+   BEFORE anything else — if they see the console login directly
+   instead, Access is not configured and this must be treated as a
+   blocking failure, not a warning.
 3. Complete the Access login
-4. **Verify you reach the Dune Console login page**
-5. Sign in with your admin password
+4. Confirm they reach the Dune Console login page
+5. Sign in with the admin password
 6. Confirm the console loads, server status displays, maps tab works
 
 ### 2.3 Setup Portal
+Ask the user to:
 1. Navigate to `https://ACP_SETUP_TUNNEL_HOSTNAME/setup`
-2. Verify the setup wizard loads
-3. Verify live stats: `https://ACP_SETUP_TUNNEL_HOSTNAME/api/live-stats`
+2. Confirm the setup wizard loads
+3. Confirm live stats load: `https://ACP_SETUP_TUNNEL_HOSTNAME/api/live-stats`
 
 ### 2.4 ACP Landing
+Ask the user to:
 1. Navigate to `https://ACP_LANDING_HOSTNAME`
-2. Verify the landing page loads
-3. Verify the stats widget shows player counts (may be 0 at first)
+2. Confirm the landing page loads
+3. Confirm the stats widget shows player counts (may legitimately be 0
+   at first)
 
 ## Phase 3: Discord Bot Verification
 
 ### 3.1 Slash Commands
-In your Discord server, run each of these commands and verify they respond:
+Ask the user to run each of the following in their Discord server and
+report whether each responds correctly:
 ```
 /dune server health     → Returns server status
 /dune server status     → Returns detailed status card
@@ -95,7 +114,7 @@ In your Discord server, run each of these commands and verify they respond:
 ```
 
 ### 3.2 Player Features
-Have a player (or a test account) verify:
+Ask the user (or a test account) to verify:
 ```
 /dune data whoami       → Shows linked character
 /dune data inventory    → Shows inventory items
@@ -103,30 +122,35 @@ Have a player (or a test account) verify:
 ```
 
 ### 3.3 Scheduled Posts (if enabled)
-If `DUNE_POST_SCHEDULE_TYPE` is set, wait for the next scheduled post
-and verify it appears in the configured channel.
+If `DUNE_POST_SCHEDULE_TYPE` is set, ask the user to wait for the next
+scheduled post and confirm it appears in the configured channel.
 
 ## Phase 4: Go-Live Cutover
 
 ### 4.1 Final Check Before Announcement
-- [ ] All CRITICAL checks from 11-e2e-verify.sh pass
-- [ ] Cloudflare Access enforced on `CONSOLE_TUNNEL_HOSTNAME`
-- [ ] Game ports reachable from WAN (cellular test passed)
-- [ ] Discord bot responds to all slash commands
-- [ ] Setup portal and landing page accessible
-- [ ] DB password rotated (different on Prod vs Dev)
-- [ ] Strong admin password set
-- [ ] Restart schedule enabled
-- [ ] DB backups enabled
-- [ ] SQLite backup timer active (C-4 fix)
-- [ ] At least one player tested connectivity from outside
+Before telling the user they're clear to announce, confirm every one of
+the following is actually true — do not assume, ask the user to confirm
+anything you can't verify directly:
+- All CRITICAL checks from `11-e2e-verify.sh` pass
+- Cloudflare Access is enforced on `CONSOLE_TUNNEL_HOSTNAME`
+- Game ports are reachable from WAN (cellular test passed)
+- Discord bot responds to all slash commands
+- Setup portal and landing page are accessible
+- DB password rotated (different on Prod vs Dev)
+- Strong admin password set
+- Restart schedule enabled
+- DB backups enabled
+- SQLite backup timer active (C-4 fix)
+- At least one player has tested connectivity from outside
 
 ### 4.2 Update Server Listing (if applicable)
-If your server is listed on community server lists, update the IP address
-to your new public IP.
+If the server is listed on community server lists, remind the user to
+update the IP address to the new public IP.
 
 ### 4.3 Announce to Player Base
-Post in your Discord community:
+Offer the user this announcement template for their Discord community,
+adjusting details to match reality rather than posting it verbatim if
+anything doesn't match:
 ```
 @everyone The server migration to new hardware is complete!
 
@@ -137,26 +161,31 @@ The server IP remains the same. If you experience any issues,
 please report them in <#support-channel>.
 ```
 
-## Phase 5: Post-Deployment Ops (start a NEW R740xd session)
+## Phase 5: Post-Deployment Ops (tell the user to start a NEW R740xd session)
 
 Performance baseline capture, first-24-hours monitoring, and
 troubleshooting commands all require SSH access to the VMs — that's
-R740-side work. Start a separate session and run
-`r740xd/04-post-deployment-ops.md` for those steps.
+R740-side work. Do not attempt any of it in this session. Tell the user
+to start a separate session and run `r740xd/04-post-deployment-ops.md`
+for those steps.
 
 ## Phase 6: Post-Deployment Evidence (back in this dev-machine session)
 
 ### 6.1 Save Verification Report
+Run:
 ```bash
 cp /tmp/opencode/e2e-report-*.txt ~/r740-deployment/compliance/evidence/go-live/
 ```
 
 ### 6.2 Complete OCI Decommissioning Evidence
-Fill in and sign `~/r740-deployment/compliance/evidence/decommissions/2026-08-07-oci-acp-bot-vnic.md`
-— **only once the OCI-to-R740 bot migration has actually been executed**
-(see `r740xd/03-bot-deploy-and-tunnel.md`); this evidence file itself is
-currently just an unexecuted template (see the file's own status note),
-and this step must not be checked off before that migration is real.
+Fill in and have the user sign
+`~/r740-deployment/compliance/evidence/decommissions/2026-08-07-oci-acp-bot-vnic.md`
+— only once the OCI-to-R740 bot migration has actually been executed
+(see `r740xd/03-bot-deploy-and-tunnel.md`). This evidence file is
+currently just an unexecuted template (see the file's own status note).
+Do not mark this step complete, or represent the migration as done,
+before that migration is real — verify with the user directly if
+uncertain.
 
 ### 6.3 Update Incident Index
 Add an entry to `~/archive/INCIDENT-INDEX.md`:
@@ -165,20 +194,27 @@ INC-2026-08-07-001 | Low | R740 migration — deployment completed, all e2e chec
 ```
 
 ### 6.4 Archive Gaming PC (after burn-in)
-Only after at least 3 days of stable production with real players, and
-after `r740xd/04-post-deployment-ops.md`'s monitoring phase looks clean:
+Only after the user confirms at least 3 days of stable production with
+real players, and after `r740xd/04-post-deployment-ops.md`'s monitoring
+phase looks clean, run:
 ```bash
 # On the gaming PC:
 bash ~/r740-deployment/scripts/07-wsl-decommission.sh
 ```
+Do not run this prematurely — ask the user to explicitly confirm burn-in
+is complete before executing.
 
-## State After Completion
-- [ ] Full E2E verification suite run, report saved
-- [ ] All CRITICAL checks passing
-- [ ] Manual WAN verification passed (cellular + incognito browser)
-- [ ] Discord bot responding to all slash commands
-- [ ] Player base announced
-- [ ] Post-deployment ops session started (`r740xd/04-post-deployment-ops.md`)
-- [ ] OCI decommissioning evidence completed (only once migration is real)
-- [ ] Incident index updated
-- [ ] Go-live evidence saved under `compliance/evidence/go-live/`
+## What to Report Back When This Prompt Is Done
+Summarize for the user, as an explicit checklist with each item marked
+done/not-done:
+- Full E2E verification suite run, report saved
+- All CRITICAL checks passing
+- Manual WAN verification passed (cellular + incognito browser)
+- Discord bot responding to all slash commands
+- Player base announced
+- Post-deployment ops session started (tell the user to start
+  `r740xd/04-post-deployment-ops.md` separately)
+- OCI decommissioning evidence completed (only once migration is real)
+- Incident index updated
+- Go-live evidence saved under `compliance/evidence/go-live/`
+</content>


### PR DESCRIPTION
## Summary

Rewrites all six deployment prompt files from human-runbook style (numbered steps, "follow the interactive prompts", checklists addressed to a person at a keyboard) to second-person imperative instructions addressed directly to the executing LLM agent (Claude Sonnet 5 via OpenCode).

## Risk classification

**Low.** Docs-only change — no scripts, no runtime behavior, no CI config touched. Blast radius is limited to how future agent sessions interpret these prompt files; no live infrastructure is affected by this PR itself.

## Scope

- `prompts/tabr-tau/00-prerequisites.md`
- `prompts/tabr-tau/04-e2e-verification.md`
- `prompts/r740xd/01-proxmox-and-vms.md`
- `prompts/r740xd/02-game-servers.md`
- `prompts/r740xd/03-bot-deploy-and-tunnel.md`
- `prompts/r740xd/04-post-deployment-ops.md`

## What changed

- Voice: "This prompt runs in its own session..." → "You are an LLM coding agent running in your own session...". Steps addressed as "you" (the agent), not narrated for a human to manually execute.
- "Follow the interactive prompts" / "Press Enter to start" phrasing replaced with explicit instructions on what values to supply and what to verify/report.
- "**VERIFY:**" checklist narration replaced with explicit reporting requirements (what to check, what output to give back to the user, when to stop vs. proceed).
- All real operational content preserved verbatim: exact commands, exact IPs/hostnames, exact verification commands and expected output, the tabr-tau (dev-machine, gathering-only) vs r740xd (R740-side install/config) session-boundary rule from issue #59, and prior corrections (boot-order bug #61, netplan static-IP installer bug, real hostname/IP values).
- Fixed a stale claim found during this rewrite: `tabr-tau/00-prerequisites.md` listed the dev machine's own OS as Ubuntu 24.04 — left over from before PR #52 updated the *VM guest* OS target to 26.04; the separate dev-machine-OS line was never updated. Confirmed via `grep -rn "24.04"` that no other stale references remain anywhere in the repo.

## Verification

- `bash tests/no-personal-identifiers.sh` — passes (no new personal identifiers introduced; all IPs/hostnames preserved from originals).
- `grep -rn "24.04"` across the whole repo — zero matches after this change.
- Manually diffed all six files to confirm every real command, IP, hostname, and prior correction survived the rewrite unchanged in substance.
- `markdown-lint` CI job only scans `docs/*.md` and `README.md`, not `prompts/`, so no relative-link risk from this change.
- Rebased onto latest `main` (picked up PR #64, an unrelated `scripts/11-e2e-verify.sh` fix) before opening this PR.

## Docs reviewed

This PR *is* the docs change (Requirement 14) — no other doc needed updating as a result; the rewritten prompts still reference `docs/01-proxmox-install.md`, `docs/02-network-setup.md`, `docs/05-dell-support-case-boot-failure.md` at the same paths as before, unchanged.

Closes #63