### PR TITLE
docs: fix stale ~/archive/INCIDENT-INDEX.md path in tabr-tau/04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ introduced them, in Keep a Changelog style, newest first.
   dune-dev/socket 1, explicitly rejecting stale range syntax like
   `0-19`) that doesn't depend on this host's specific CPU numbering.
   (#62)
+- `prompts/tabr-tau/04-e2e-verification.md` Phase 6.3 referenced a stale
+  `~/archive/INCIDENT-INDEX.md` path that never actually existed — per
+  the Arrakis-Project meta-repo README's own 2026-08-12 correction, this
+  file has only ever lived at
+  `~/projects/meta/Arrakis-Project/archive/INCIDENT-INDEX.md`. This
+  prompt was never updated to match that correction. (#69)
 
 ### Fixed
 

--- a/prompts/tabr-tau/04-e2e-verification.md
+++ b/prompts/tabr-tau/04-e2e-verification.md
@@ -188,7 +188,11 @@ before that migration is real — verify with the user directly if
 uncertain.
 
 ### 6.3 Update Incident Index
-Add an entry to `~/archive/INCIDENT-INDEX.md`:
+Add an entry to
+`~/projects/meta/Arrakis-Project/archive/INCIDENT-INDEX.md` (issue #69 —
+this file has only ever actually lived in the Arrakis-Project meta-repo,
+never at a bare `~/archive/` path; verify the file exists there before
+assuming any other location):
 ```
 INC-2026-08-07-001 | Low | R740 migration — deployment completed, all e2e checks passed, zero incidents
 ```


### PR DESCRIPTION
Closes #69.

## Summary
`prompts/tabr-tau/04-e2e-verification.md` Phase 6.3 referenced `~/archive/INCIDENT-INDEX.md`, a path that never actually existed. Per the Arrakis-Project meta-repo README's own 2026-08-12 correction, this file has only ever lived at `~/projects/meta/Arrakis-Project/archive/INCIDENT-INDEX.md`. Confirmed directly on the Tabr-Tau dev machine's filesystem: the bare path doesn't exist, the real one does.

## Risk classification
**Low.** Documentation-only path correction in a not-yet-executed go-live evidence step (Phase 6, only reached after full deployment + burn-in). No impact on any already-running infrastructure.

## What changed
- `prompts/tabr-tau/04-e2e-verification.md`: corrected the path, with a note explaining why.
- `CHANGELOG.md` updated.

## Docs reviewed
Checked for the same stale pattern elsewhere in this repo (none found beyond this one occurrence) and in sibling repos under this account — found the same pattern in `dune-ops-observability-addon/compliance/README.md`, out of scope for this PR, noting separately rather than silently leaving it.

## Verification
- Markdown code-fence balance — 14 (even)
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff