### PR TITLE
docs: create compliance/evidence/go-live/ + defensive mkdir in tabr-tau/04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ introduced them, in Keep a Changelog style, newest first.
   file has only ever lived at
   `~/projects/meta/Arrakis-Project/archive/INCIDENT-INDEX.md`. This
   prompt was never updated to match that correction. (#69)
+- `prompts/tabr-tau/04-e2e-verification.md` Phase 6.1's `cp` command
+  targeted `compliance/evidence/go-live/`, a directory that did not
+  exist anywhere in the repo (git doesn't track empty directories, and
+  unlike `compliance/evidence/decommissions/` this one had no tracked
+  file yet to keep it present) — would have failed with "No such file
+  or directory" if run verbatim on a fresh clone. Added a `mkdir -p`
+  before the `cp`, plus a `.gitkeep` so the directory exists from a
+  fresh clone even before this step runs. (#71)
 
 ### Fixed
 

--- a/prompts/tabr-tau/04-e2e-verification.md
+++ b/prompts/tabr-tau/04-e2e-verification.md
@@ -174,8 +174,13 @@ for those steps.
 ### 6.1 Save Verification Report
 Run:
 ```bash
+mkdir -p ~/r740-deployment/compliance/evidence/go-live/
 cp /tmp/opencode/e2e-report-*.txt ~/r740-deployment/compliance/evidence/go-live/
 ```
+The `mkdir -p` is required: `compliance/evidence/go-live/` does not
+exist by default in a fresh clone (issue #71 — git doesn't track empty
+directories, and unlike `compliance/evidence/decommissions/` this one
+has no tracked file yet to keep it present).
 
 ### 6.2 Complete OCI Decommissioning Evidence
 Fill in and have the user sign


### PR DESCRIPTION
Closes #71.

## Summary
`prompts/tabr-tau/04-e2e-verification.md` Phase 6.1's `cp` command targeted `compliance/evidence/go-live/`, a directory that did not exist anywhere in the repo — confirmed via the real git tree (`compliance/evidence/decommissions/` exists only because it already has a real tracked file; `go-live/` had neither content nor a `.gitkeep`). Running Phase 6.1 verbatim on a fresh clone would fail with "No such file or directory".

## Risk classification
**Low.** Documentation/scaffolding gap in a not-yet-executed go-live evidence step (Phase 6, only reached after full deployment + burn-in + all e2e checks passing). No impact on any already-running infrastructure.

## What changed
- Added `compliance/evidence/go-live/.gitkeep` so the directory exists from a fresh clone.
- Added `mkdir -p` immediately before the `cp` in the prompt itself, for defense in depth (resilient even if the placeholder is later removed) — matches this repo's own existing pattern (e.g. `mkdir -p "$(dirname "$REPORT")"` in `scripts/11-e2e-verify.sh`).
- `CHANGELOG.md` updated.

## Docs reviewed
Checked for other `compliance/evidence/*` references across the repo that might have the same gap — none found beyond this one.

## Verification
- Markdown code-fence balance — 14 (even)
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff