### PR TITLE
docs: fix wrong /dune data whoami|inventory|storage commands in tabr-tau/04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,18 @@ introduced them, in Keep a Changelog style, newest first.
   or directory" if run verbatim on a fresh clone. Added a `mkdir -p`
   before the `cp`, plus a `.gitkeep` so the directory exists from a
   fresh clone even before this step runs. (#71)
+- `prompts/tabr-tau/04-e2e-verification.md` Phase 3.2 told the agent to
+  verify `/dune data whoami`, `/dune data inventory`, and
+  `/dune data storage` — these commands don't exist under the `data`
+  subcommand group. Confirmed against `arrakis-control-panel`'s real,
+  currently-registered command set (`src/commands.js`'s
+  `commandDefinitions()`, corroborated by `test/commands.test.js`): the
+  `data` group only has `population`/`backups`/`maps`, and the real
+  character/inventory/storage commands are registered under `player`
+  (`player:whoami`, `player:inventory`, `player:storage`). Running the
+  prompt's commands verbatim in Discord would have failed. Phase 3.1's
+  five commands were independently cross-checked against the same real
+  command list and are all correct. (#73)
 
 ### Fixed
 

--- a/prompts/tabr-tau/04-e2e-verification.md
+++ b/prompts/tabr-tau/04-e2e-verification.md
@@ -114,11 +114,14 @@ report whether each responds correctly:
 ```
 
 ### 3.2 Player Features
-Ask the user (or a test account) to verify:
+Ask the user (or a test account) to verify (issue #73 — these are
+registered under the `player` subcommand group, not `data`; confirmed
+against `arrakis-control-panel/src/commands.js`'s real
+`commandDefinitions()`):
 ```
-/dune data whoami       → Shows linked character
-/dune data inventory    → Shows inventory items
-/dune data storage      → Shows storage contents
+/dune player whoami      → Shows linked character
+/dune player inventory   → Shows inventory items
+/dune player storage     → Shows storage contents
 ```
 
 ### 3.3 Scheduled Posts (if enabled)


### PR DESCRIPTION
Closes #73.

## Summary
`prompts/tabr-tau/04-e2e-verification.md` Phase 3.2 told the agent to verify `/dune data whoami`, `/dune data inventory`, and `/dune data storage`. These commands don't exist under the `data` subcommand group. Confirmed against `arrakis-control-panel`'s real, currently-registered command set (`src/commands.js`'s `commandDefinitions()`, corroborated by `test/commands.test.js`): the `data` group only has `population`/`backups`/`maps`; the real character/inventory/storage commands are registered under `player` (`player:whoami`, `player:inventory`, `player:storage`). Running the prompt's commands verbatim in Discord would fail.

## Risk classification
**Low.** Documentation-only correction in a not-yet-executed go-live verification phase (Phase 3, reached only after full deployment). No impact on any already-running infrastructure — purely about the prompt text matching the bot's real, current command surface.

## What changed
- `prompts/tabr-tau/04-e2e-verification.md`: corrected Phase 3.2's three commands, with a note explaining the source of truth.
- `CHANGELOG.md` updated.

## Docs reviewed
Cross-checked Phase 3.1's five commands (`server health`, `server status`, `data population`, `server readiness`, `core ping`) against the same real command list — all five are correct, no changes needed there.

## Verification
- Markdown code-fence balance — 14 (even)
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff