### PR TITLE
docs: qualify cross-repo issue #81 reference in tabr-tau/00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ introduced them, in Keep a Changelog style, newest first.
   prompt's commands verbatim in Discord would have failed. Phase 3.1's
   five commands were independently cross-checked against the same real
   command list and are all correct. (#73)
+- `prompts/tabr-tau/00-prerequisites.md`'s SSH-key comment referenced
+  bare "issue #81", which doesn't exist in this repo — it's actually
+  `arrakis-control-panel#81`, unqualified. Qualified the reference
+  explicitly. (#75)
 
 ### Fixed
 

--- a/prompts/tabr-tau/00-prerequisites.md
+++ b/prompts/tabr-tau/00-prerequisites.md
@@ -53,7 +53,8 @@ machine.
 ### 2. Verify SSH Keys
 Run:
 ```bash
-# The SSH key used for deploy remote (issue #81)
+# The SSH key used for deploy remote (arrakis-control-panel#81 -- a
+# different repo; #81 does not exist in this repo)
 ls -la ~/.ssh/ssh-key-2026-07-18.key
 chmod 600 ~/.ssh/ssh-key-2026-07-18.key
 ```


### PR DESCRIPTION
Closes #75.

## Summary
`prompts/tabr-tau/00-prerequisites.md`'s SSH-key comment referenced bare "issue #81", which doesn't exist in this repo (confirmed: ~30 issues total, none numbered 81). It's actually `arrakis-control-panel#81`, unqualified — a reader following this reference as written would get a confusing "issue not found" checking this repo's own tracker.

## Risk classification
**Low.** Documentation-only reference-format fix. No functional impact.

## What changed
- `prompts/tabr-tau/00-prerequisites.md`: qualified the cross-repo reference explicitly.
- `CHANGELOG.md` updated.

## Verification
- Markdown code-fence balance — 8 (even)
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff