### PR TITLE
docs: accept _FILE secret pattern in tabr-tau/00 Step 4 key check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ introduced them, in Keep a Changelog style, newest first.
   bare "issue #81", which doesn't exist in this repo — it's actually
   `arrakis-control-panel#81`, unqualified. Qualified the reference
   explicitly. (#75)
+- `prompts/tabr-tau/00-prerequisites.md` Step 4's key-presence check
+  expected `DISCORD_BOT_TOKEN=` and `DUNE_DISCORD_ADAPTER_TOKEN=`
+  inline, but the real deployment's `.env` uses the `_FILE`-suffixed
+  pattern for both (pointing at secret files elsewhere on the host
+  rather than storing values inline) — found by actually executing this
+  step against the live OCI bot host and diagnosing why two of the four
+  expected keys appeared "missing." The deployment is not
+  misconfigured; the `_FILE` pattern is the better practice per this
+  project's own Requirement 24. Updated the check to accept either
+  form. (#78)
 
 ### Fixed
 

--- a/prompts/tabr-tau/00-prerequisites.md
+++ b/prompts/tabr-tau/00-prerequisites.md
@@ -125,12 +125,18 @@ chmod 600 ~/r740-bot-backup/secrets/*
 
 Verify `bot-env.txt` contains at minimum the following keys, and report
 which are present/missing (never print the actual secret values back to
-the user in chat):
-- `DISCORD_BOT_TOKEN=`
+the user in chat). Check key *names* only via `grep -q`/`grep -c`, never
+the file's contents:
+- `DISCORD_BOT_TOKEN=` OR `DISCORD_BOT_TOKEN_FILE=` (issue #78 — this
+  deployment uses the `_FILE` pattern for this key, pointing at a
+  secret file elsewhere on the host rather than storing the token
+  inline; both forms are valid, prefer `_FILE` per this project's own
+  Requirement 24)
 - `DISCORD_CLIENT_ID=`
 - `DUNE_CONSOLE_API_URL=` (will be changed to `http://localhost:8088`
   during the actual R740-side deployment, not here)
-- `DUNE_DISCORD_ADAPTER_TOKEN=`
+- `DUNE_DISCORD_ADAPTER_TOKEN=` OR `DUNE_DISCORD_ADAPTER_TOKEN_FILE=`
+  (issue #78 — same `_FILE` pattern as above)
 
 ### 5. Report Final Status Before Moving to r740xd/01
 Report the status of each of the following back to the user as a


### PR DESCRIPTION
Closes #78.

## Summary
Executed Step 4 for real against the live OCI bot host this session. `DISCORD_CLIENT_ID` and `DUNE_CONSOLE_API_URL` were present as expected, but `DISCORD_BOT_TOKEN` and `DUNE_DISCORD_ADAPTER_TOKEN` initially looked missing. Checked the actual key names present (names only, values never inspected) and found the real deployment uses the `_FILE`-suffixed pattern for both — pointing at secret files elsewhere on the host rather than storing values inline. The deployment is not misconfigured — this is the better practice per this project's own Requirement 24 (prefer `_FILE` variants over env-var secrets). The prompt's checklist was simply never updated to match.

## Risk classification
**Low.** Documentation-only fix to a verification checklist. No secret values were included in the issue or this fix — only key names were inspected to diagnose the discrepancy, never values.

## What changed
- `prompts/tabr-tau/00-prerequisites.md`: Step 4 now accepts either `KEY=` or `KEY_FILE=` for the two secret keys, with a note on which pattern this deployment actually uses and why.
- `CHANGELOG.md` updated.

## Verification
- Markdown code-fence balance — 8 (even)
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff