### PR TITLE
feat: preserve runtime/secrets/ and runtime/generated/ across migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ introduced them, in Keep a Changelog style, newest first.
 
 ### Changed
 
+- `scripts/06-pre-migration-backup.sh` now also stages `runtime/secrets/`
+  and `runtime/generated/` for transfer, in addition to the DB backup it
+  already staged — neither directory was previously captured by any
+  migration step, despite `runtime/secrets/` holding credential material
+  with no other source of truth (e.g. the Funcom token). Audited both
+  directories against the real, live host before implementing: found
+  10 real secret files in `runtime/secrets/` and confirmed `runtime/generated/`
+  is dominated by ~295 ephemeral `dune-fake-k8s-serviceaccount-<service>-<pid>`
+  directories recreated on every container restart (not real state, see
+  `runtime/scripts/spawn-server.sh`) — the new `runtime/generated/` tar
+  excludes those plus rotating `*.log` files, keeping every other
+  config/state file (`battlegroup.env`, `sietch-config.json`,
+  `care-package*`, etc.). `runtime/addons/` is explicitly out of scope
+  — addons are easily reinstalled (operator decision, 2026-08-14).
+  Caught and fixed a real bug during implementation, before it shipped:
+  GNU `tar`'s `--exclude` flags are positional and must precede the
+  archive-path arguments or they're silently ignored (verified via a
+  synthetic test directory both before and after the fix — the original
+  flag ordering archived everything, excludes included, with no error).
+  (#80)
+
 - Rewrote all six `prompts/tabr-tau/*` and `prompts/r740xd/*` deployment
   prompt files from human-runbook style (numbered steps, "follow the
   interactive prompts", checklists addressed to a person at a keyboard)

--- a/scripts/06-pre-migration-backup.sh
+++ b/scripts/06-pre-migration-backup.sh
@@ -9,9 +9,25 @@
 #           7/24 rehearsal backup taken earlier in this project - that one
 #           stays only as a rollback reference, this one is the real source.
 #
-#           Also stages the backup file, its sidecar metadata, and a
-#           redacted .env reference into a single directory for easy
-#           transfer off this box.
+#           Also stages the backup file, its sidecar metadata, a
+#           redacted .env reference, and tarballs of runtime/secrets/
+#           and runtime/generated/ into a single directory for easy
+#           transfer off this box (issue #80 -- neither directory was
+#           previously captured by any migration step; runtime/secrets/
+#           holds credential material with no other source of truth,
+#           e.g. the Funcom token, which may not be re-issuable on
+#           demand). runtime/generated/'s tar deliberately excludes the
+#           dune-fake-k8s-serviceaccount-<service>-<pid> directories
+#           (recreated fresh on every container restart -- see
+#           runtime/scripts/spawn-server.sh's FAKE_K8S_SERVICEACCOUNT_DIR,
+#           not real state) and rotating *.log files, keeping every
+#           other config/state file.
+#
+#           runtime/addons/ is explicitly NOT captured here -- addons are
+#           easily reinstalled, no preservation needed (operator
+#           decision, 2026-08-14). The existing addon state.json
+#           reference below predates that decision and is kept as-is
+#           since it's a small, already-working, separate mechanism.
 #
 # PREREQ:   Run from inside: /home/darkdante/dune-awakening-selfhost-docker
 #
@@ -70,6 +86,36 @@ sha256sum "$LATEST_BACKUP" > "$STAGING_DIR/$(basename "$LATEST_BACKUP").sha256"
 grep -v -i "token\|password\|secret" .env > "$STAGING_DIR/env-reference-redacted.txt"
 cp runtime/addons/state.json "$STAGING_DIR/addon-state-reference.json" 2>/dev/null || true
 
+echo
+echo "--- Staging runtime/secrets/ (issue #80) ---"
+if [ -d runtime/secrets ]; then
+  tar -czf "$STAGING_DIR/runtime-secrets.tar.gz" -C runtime secrets
+  echo "Staged runtime-secrets.tar.gz ($(du -h "$STAGING_DIR/runtime-secrets.tar.gz" | cut -f1))"
+else
+  echo "WARNING: runtime/secrets/ not found -- skipping. This is unexpected"
+  echo "unless this is a fresh, never-initialized install."
+fi
+
+echo
+echo "--- Staging runtime/generated/ (issue #80) ---"
+if [ -d runtime/generated ]; then
+  # --exclude flags are positional in GNU tar and must come BEFORE the
+  # archive path arguments, or they're silently ignored with a warning
+  # (confirmed by testing this exact command against a synthetic
+  # directory before trusting it against real data -- the original
+  # ordering here archived everything, excludes included, with no
+  # error, just a warning easy to miss in scrollback).
+  tar --exclude='generated/dune-fake-k8s-serviceaccount-*' \
+      --exclude='generated/*.log' \
+      -czf "$STAGING_DIR/runtime-generated.tar.gz" -C runtime generated
+  echo "Staged runtime-generated.tar.gz ($(du -h "$STAGING_DIR/runtime-generated.tar.gz" | cut -f1))"
+  echo "(excludes dune-fake-k8s-serviceaccount-* ephemeral dirs and *.log files --"
+  echo " neither is real state, see this script's header comment)"
+else
+  echo "WARNING: runtime/generated/ not found -- skipping. This is unexpected"
+  echo "unless this is a fresh, never-initialized install."
+fi
+
 chmod 600 "$STAGING_DIR"/*
 
 echo
@@ -81,11 +127,21 @@ cat "$STAGING_DIR/$(basename "$LATEST_BACKUP").sha256"
 echo
 echo "=== NEXT STEP: transfer this off the gaming PC ==="
 echo
-echo "Once dune-dev's VM is up and reachable, transfer with:"
+echo "Once dune-dev's VM is up and reachable, transfer the DB backup with:"
 echo "  scp $STAGING_DIR/*.backup* <dev-vm-user>@<dev-vm-ip>:~/dune-awakening-selfhost-docker/runtime/backups/db/"
 echo
 echo "Then on the dune-dev VM, verify integrity before importing:"
 echo "  sha256sum ~/dune-awakening-selfhost-docker/runtime/backups/db/$(basename "$LATEST_BACKUP")"
 echo "  (compare against the .sha256 file transferred alongside it)"
+echo
+echo "Separately, transfer and restore runtime/secrets/ and runtime/generated/"
+echo "(issue #80) onto EACH VM that needs them (both dune-prod and dune-dev if"
+echo "both are meant to carry forward this host's config/credentials -- decide"
+echo "this per-value, do not assume a blanket copy to both is correct):"
+echo "  scp $STAGING_DIR/runtime-secrets.tar.gz $STAGING_DIR/runtime-generated.tar.gz \\"
+echo "      <vm-user>@<vm-ip>:~/dune-awakening-selfhost-docker/runtime/"
+echo "  ssh <vm-user>@<vm-ip> 'cd ~/dune-awakening-selfhost-docker/runtime && \\"
+echo "      tar -xzf runtime-secrets.tar.gz && tar -xzf runtime-generated.tar.gz && \\"
+echo "      chmod 600 secrets/* && rm runtime-secrets.tar.gz runtime-generated.tar.gz'"
 echo
 echo "Then proceed with 04-init-dev-battlegroup.sh on the dune-dev VM."


### PR DESCRIPTION
Closes #80.

## Summary
Neither `runtime/secrets/` nor `runtime/generated/` was previously captured by any migration step, despite `runtime/secrets/` holding credential material with no other source of truth (Funcom token, admin password, Discord adapter token, OAuth client secret, FLS API key, and others — 10 files total, confirmed against the real, live host).

## What was audited (against the real, live host)
- **`runtime/secrets/`**: 10 files, 44K, all `600` — genuine credential material, no source of truth elsewhere.
- **`runtime/generated/`**: 377 files, but dominated by ~295 ephemeral `dune-fake-k8s-serviceaccount-<service>-<pid>` directories recreated fresh on every container restart (confirmed via `runtime/scripts/spawn-server.sh`'s `FAKE_K8S_SERVICEACCOUNT_DIR` — not real state) plus rotating `*.log` files. The new tar excludes both, keeping every other config/state file (`battlegroup.env`, `sietch-config.json`, `care-package*`, `map-runtime-modes.json`, and ~50 others).
- `runtime/addons/` is explicitly out of scope — addons are easily reinstalled (operator decision, 2026-08-14).

## Risk classification
**Low.** Additive change to an existing pre-migration staging script. Does not modify anything already running, only reads/tars the two directories. The new tars are optional inputs to a later manual restore step, not auto-applied.

## Bug caught during implementation (before shipping)
GNU `tar`'s `--exclude` flags are positional and must precede the archive-path arguments, or they're silently ignored with only an easy-to-miss warning. Verified via a synthetic test directory both before the fix (confirmed everything was archived, excludes had no effect) and after (confirmed the ephemeral dir and log file were correctly excluded, real config files correctly kept).

## What changed
- `scripts/06-pre-migration-backup.sh`: stages `runtime-secrets.tar.gz` and `runtime-generated.tar.gz` alongside the existing DB backup, same `chmod 700`/`600` staging-directory treatment. Updated transfer instructions to cover both, with an explicit note that per-VM restoration should be a deliberate decision, not a blanket copy to both `dune-prod` and `dune-dev`.
- `CHANGELOG.md` updated.

## Verification
- `bash -n` syntax check — clean
- `shellcheck -S warning` — clean
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff