### PR TITLE
docs: reference runtime/secrets|generated backup in downstream prompts

### DIFF
--- a/docs/00-START-HERE.md
+++ b/docs/00-START-HERE.md
@@ -153,7 +153,11 @@ and moved several previously-misplaced steps between files.
    `scripts/03-vm-guest-bootstrap.sh` inside each VM.
 5. On the gaming PC, the night before or morning of cutover, run
    `scripts/06-pre-migration-backup.sh` to take the final DB backup and
-   stage it for transfer.
+   stage it for transfer, along with `runtime/secrets/` and
+   `runtime/generated/` tarballs (issue #80 — decide per-value whether
+   Dev's credentials/config should carry forward or start fresh via
+   `dune init`; `runtime/addons/` is intentionally not staged, since
+   addons are easily reinstalled).
 6. Continuing the R740xd session (or a fresh one),
    `prompts/r740xd/02-game-servers.md` covers both battlegroup
    initializations (`scripts/04-init-dev-battlegroup.sh` importing the

--- a/docs/03-runbook-day-of.md
+++ b/docs/03-runbook-day-of.md
@@ -30,6 +30,14 @@ Print this or keep it open on a second device. Check off each step.
       `dune-dev`'s `runtime/backups/db/` directory
 - [ ] On `dune-dev`, verify the checksum matches before importing:
       `sha256sum <file> ` vs the transferred `.sha256`
+- [ ] Decide whether Dev should carry forward the gaming PC's
+      `runtime/secrets/` and `runtime/generated/` (issue #80), or get
+      fresh values from `dune init` below — if carrying forward, `scp`
+      + extract `runtime-secrets.tar.gz` and `runtime-generated.tar.gz`
+      from the same staging directory onto `dune-dev` BEFORE running
+      `dune init`, and `chmod 600` the extracted secrets files
+      (`runtime/addons/` is intentionally not part of this — addons are
+      easily reinstalled)
 
 ## Battlegroup Initialization
 

--- a/prompts/r740xd/02-game-servers.md
+++ b/prompts/r740xd/02-game-servers.md
@@ -40,6 +40,29 @@ All checksums must report "OK". If any fail, stop and do not import —
 report the failure to the user rather than proceeding with a possibly
 corrupt backup.
 
+### 1.1 Transfer and Restore runtime/secrets/ and runtime/generated/ (issue #80)
+
+`scripts/06-pre-migration-backup.sh` also stages `runtime-secrets.tar.gz`
+and `runtime-generated.tar.gz` in the same staging directory. Decide
+per-value whether Dev needs the gaming PC's credentials/config carried
+forward, or whether it should get its own fresh `runtime/secrets/` from
+`dune init` below (issue #80's fix intentionally leaves this a manual
+decision, not a blanket copy) — ask the user if unclear. If restoring
+onto Dev:
+```bash
+scp /tmp/opencode/dune-migration-final/runtime-secrets.tar.gz \
+    /tmp/opencode/dune-migration-final/runtime-generated.tar.gz \
+    dune@192.168.21.10:~/dune-awakening-selfhost-docker/runtime/
+ssh dune@192.168.21.10 "cd ~/dune-awakening-selfhost-docker/runtime && \
+    tar -xzf runtime-secrets.tar.gz && tar -xzf runtime-generated.tar.gz && \
+    chmod 600 secrets/* && rm runtime-secrets.tar.gz runtime-generated.tar.gz"
+```
+If restoring, do this BEFORE running `dune init` in Phase 2 below, so
+`init` sees the carried-forward `runtime/secrets/funcom-token.txt`
+rather than prompting fresh. If Dev should get fresh credentials
+instead, skip this step entirely and let `dune init` create
+`runtime/secrets/` from scratch.
+
 ## Phase 2: Initialize Dev Battlegroup (WITH backup import)
 
 ### 2.1 Run dune init


### PR DESCRIPTION
Follow-up to #80, per operator request.

## Summary
PR #81 (issue #80) added `runtime-secrets.tar.gz` and `runtime-generated.tar.gz` staging to `scripts/06-pre-migration-backup.sh`, but the three docs that reference this script's output — the actual downstream consumers — were never updated to mention them, leaving the same gap one level downstream.

## Risk classification
**Low.** Documentation-only change. No script/automation behavior modified — only the prompts/docs that describe an existing script's (already-shipped) output.

## What changed
- `prompts/r740xd/02-game-servers.md`: new Phase 1.1 covering transfer and restore of both tarballs onto `dune-dev`, explicitly sequenced BEFORE `dune init` (so init sees carried-forward secrets rather than prompting fresh) and framed as a per-value decision, not a blanket copy — matching issue #80's own fix intent.
- `docs/00-START-HERE.md`: step 5's summary now mentions the two new tarballs.
- `docs/03-runbook-day-of.md`: new Backup Transfer checklist item for the same decision/restore step.

All three consistently note `runtime/addons/` is intentionally excluded (easily reinstalled, operator decision 2026-08-14).

## Verification
- Markdown code-fence balance — 42/4/0, all even
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff