### PR TITLE
docs: reverse Step 5 Dev-no-forwards decision, configure Dev as multi-server Instance 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ introduced them, in Keep a Changelog style, newest first.
 
 ### Changed
 
+- `docs/02-network-setup.md` Step 5: reversed the prior "Dev gets no
+  port forwards at all... LAN/VPN-only, no public testers" decision.
+  Dev now gets real WAN port forwards using a distinct, collision-free
+  port profile (multi-server guide's Instance 2, `+1000` offset) from
+  `dune-awakening-selfhost-docker`'s
+  `docs/runtime/MULTI-SERVER-SINGLE-PUBLIC-IP.md` guide and its
+  `runtime/scripts/multi-server-config.py` helper. Prod remains
+  Instance 1 (unchanged stock ports). Independently validated the
+  helper script against a real checkout before relying on it — found
+  and confirmed it only works when paired with its companion
+  `start-rabbitmq.sh` change (both bundled in fork PR #262 /
+  upstream-fork PR #156, neither yet merged), and that dune-dev's
+  originally-installed fork tag (`v1.3.37`, June 2026) predates the
+  entire port-configurability feature — resolved by moving dune-dev's
+  checkout to the fork's `main` branch (which includes it) rather than
+  hand-patching an old tag. (#83)
+
 - `scripts/06-pre-migration-backup.sh` now also stages `runtime/secrets/`
   and `runtime/generated/` for transfer, in addition to the DB backup it
   already staged — neither directory was previously captured by any

--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -91,6 +91,14 @@ announced maintenance window) — repointing a live game server's
 forwards while players are connected would disconnect them mid-session
 with no warning. Steps 6 onward not yet started.
 
+**Update (2026-08-14, issue #83):** Step 5's original scope was Prod
+port forwards only, with Dev deliberately left LAN/VPN-only. That
+decision has since been reversed — Dev now also gets real WAN port
+forwards, using a distinct, collision-free port profile (Instance 2 of
+the multi-server guide) so it never shares a numeric port with Prod.
+See Step 5 below for the current, authoritative version of this
+step's scope and the Dev-specific port table.
+
 ## Initial Setup
 
 1. Connect the UCG-Max's WAN port (the 2.5GbE RJ45 port labeled/default
@@ -281,18 +289,41 @@ new zones — this handles DHCP/DNS/management traffic for the UCG-Max
 itself, and blocking it can break basic network function in
 hard-to-diagnose ways.
 
-## Step 5: WAN Port Forwards (Prod ONLY)
+## Step 5: WAN Port Forwards
 
-**This step is a cutover, not an additive setup step — do it last, and
-only when dune-prod is actually ready to take over.** If this gateway
-already has an active game server running on the old flat Trusted-LAN
-(true for this deployment: forwards already exist pointing at a
-currently-live game server), do NOT create a second, parallel set of
-forwards pointing at the new Prod VLAN IP ahead of time — nothing is
-listening there until the new dune-prod VM exists and is actually
-running the game server, so an early forward is dead weight at best,
-and repointing the *existing* forwards early would disconnect real
-players with no warning.
+**Decision reversed (2026-08-14, issue #83):** this step previously said
+"Dev gets no port forwards at all... LAN/VPN-only, no public testers."
+That is no longer the decision — Dev now gets real WAN port forwards
+using a distinct, collision-free port profile so it can be reached
+directly by players/testers, without ever sharing a numeric port with
+Prod. This uses `dune-awakening-selfhost-docker`'s own
+[multi-server / single-public-IP guide](https://github.com/yacketrj/dune-awakening-selfhost-docker/blob/agent/multi-server-single-public-ip-guide/docs/runtime/MULTI-SERVER-SINGLE-PUBLIC-IP.md)
+and its `runtime/scripts/multi-server-config.py` helper (independently
+validated against a real checkout — see issue #83 and the PR that
+resolved it for the validation evidence) rather than an ad hoc port
+choice.
+
+**Instance mapping for this deployment:**
+
+- **dune-prod = Instance 1** — stock/default ports, unchanged from
+  today's values. No `.env` or UserEngine change needed on Prod for
+  this step.
+- **dune-dev = Instance 2** — the standard `+1000` offset from the
+  multi-server guide.
+
+**This step is a cutover for Prod, but an additive setup step for Dev —
+do the Prod cutover last, and only when dune-prod is actually ready to
+take over.** If this gateway already has an active game server running
+on the old flat Trusted-LAN (true for this deployment: forwards already
+exist pointing at a currently-live game server), do NOT create a second,
+parallel set of forwards pointing at the new Prod VLAN IP ahead of
+time — nothing is listening there until the new dune-prod VM exists and
+is actually running the game server, so an early forward is dead weight
+at best, and repointing the *existing* forwards early would disconnect
+real players with no warning. Dev's forwards have no such constraint —
+create them as soon as dune-dev's battlegroup is initialized and its
+Instance 2 profile is applied (see below), since nothing else is using
+those ports.
 
 **All three ports are required, including 31983** — this is not an
 internal-only port that can be skipped. Confirmed via the upstream
@@ -322,6 +353,23 @@ rules to point at **dune-prod's VM IP**:
 | Dune RMQ Game | 31982 | 192.168.20.10 | 31982 | TCP |
 | Dune RMQ HTTP | 31983 | 192.168.20.10 | 31983 | TCP |
 
+**Dev's forwards (Instance 2 — new as of issue #83):** create these as
+soon as dune-dev's battlegroup is initialized and the multi-server
+Instance 2 profile has been applied (`multi-server-config.py apply
+--instance 2 --public-ip <public-ip> --bind-ip 192.168.21.10` from a
+`dune-awakening-selfhost-docker` checkout that has the multi-server
+guide's port-configurability feature — the fork's `main` branch as of
+this writing, not the base v1.3.37 tag, which predates it). Unlike
+Prod's forwards above, these are **additive, not a cutover** — nothing
+else uses these ports, so there's no live-traffic risk in creating them
+as soon as Dev is ready:
+
+| Name | WAN Port(s) | Forward IP | Forward Port(s) | Protocol |
+|---|---|---|---|---|
+| Dune Dev Game Traffic | 8777-8810 | 192.168.21.10 | 8777-8810 | UDP |
+| Dune Dev RMQ Game | 32982 | 192.168.21.10 | 32982 | TCP |
+| Dune Dev RMQ HTTP | 32983 | 192.168.21.10 | 32983 | TCP |
+
 **Do NOT create a port forward for 8088 (admin console) on either VM.**
 This is intentional — the admin console is reached via VPN only (Step 6),
 never directly from the internet. This directly closes the CRIT-01-class
@@ -330,9 +378,6 @@ currently has its console tunnel hostname pointed at the console over a
 Cloudflare Tunnel with no additional access gate — don't reproduce that
 here without at least Cloudflare Access in front of it, see
 `04-post-standup-hardening.md`).
-
-**Dev gets no port forwards at all** — per the original Phase 0 decision,
-Dev is LAN/VPN-only, no public testers.
 
 ## Step 6: VPN Access for Remote Admin
 


### PR DESCRIPTION
## Risk classification

**Low.** Documentation-only change to `r740-dune-deployment-kit` (this
repo). No code, no live-system change. Reverses a previously-documented
network-exposure decision (Dev: LAN/VPN-only -> real WAN forwards) --
the actual UCG-Max/firewall change this describes has NOT been applied
yet (no API access to that device from this tooling; it's a manual,
web-UI-driven step per this doc's own established convention). This PR
only updates the plan; applying it against the live UCG-Max is a
separate, manual follow-up.

## Summary

Closes #83. Reverses `docs/02-network-setup.md` Step 5's "Dev gets no
port forwards at all... LAN/VPN-only, no public testers" decision. Dev
now gets real WAN port forwards using a distinct, collision-free port
profile (Instance 2, `+1000` offset) from
`dune-awakening-selfhost-docker`'s own
[multi-server / single-public-IP guide](https://github.com/yacketrj/dune-awakening-selfhost-docker/blob/agent/multi-server-single-public-ip-guide/docs/runtime/MULTI-SERVER-SINGLE-PUBLIC-IP.md),
so it never numerically collides with Prod (Instance 1, unchanged stock
ports).

## Validation performed before writing this doc

Did not trust the referenced `multi-server-config.py` helper script
blindly -- independently validated it in a disposable sandbox against
real repository source files pulled from both live VMs:

- **Found it depends on a companion change** to
  `runtime/scripts/start-rabbitmq.sh` (adds `RMQ_GAME_LOCAL_HTTP_PORT`)
  that's bundled in the same, still-unmerged PR (fork #262 /
  upstream-fork #156) as the script itself -- confirmed the script
  alone throws `ConfigError` against a checkout missing that change.
- **Found dune-dev's originally-installed fork tag (`v1.3.37`, June
  2026) predates the entire port-configurability feature** --
  `POSTGRES_PORT`/`RMQ_*_PORT` don't exist anywhere in that tag's
  `runtime-env.sh` at all, confirmed against all 30 real fork tags
  (none have it). Fork's `main` branch (`391516ed`, Aug 11) does have
  it. Resolved by moving dune-dev's checkout from the `v1.3.37` tag to
  the fork's `main` branch (which the referenced PR #262 branch is
  cleanly 16 commits ahead of, 0 behind) rather than hand-patching an
  old tag.
- **Verified dune-prod (upstream, Instance 1) needs no code change at
  all** for this -- Instance 1's profile is upstream's own existing
  stock defaults, confirmed by running `plan --instances 2` against a
  copy of dune-prod's actual current `runtime-env.sh`/`usersettings.py`
  and diffing the output against the published guide's tables (exact
  match).
- **Independently re-verified the collision-detection algorithm**
  itself (not just trusted its own claims): confirmed it correctly
  flags overlapping ranges (boundary-inclusive), correctly allows
  adjacent non-overlapping ranges, and that `--dry-run` genuinely
  touches no files (`.env` byte-identical before/after).
- **Verified the real `.env` write path** (`upsert_env`) is idempotent,
  correctly deduplicates repeated/stale key definitions, and preserves
  unrelated existing keys.
- Confirmed dune-prod stays on a byte-for-byte upstream `main` mirror
  for this change -- deliberately did NOT hand-patch dune-prod's
  checkout with the unmerged #262/#156 diff, since that would violate
  this deployment's own "Prod mirrors upstream exactly" principle.
  Only dune-dev (which is expected to track our fork, including
  in-flight work) picked up the newer branch.

## Scope

- `docs/02-network-setup.md` only -- Step 5 rewritten, stale duplicate
  "Dev gets no forwards" line removed, status header at top annotated
  (not rewritten -- preserves historical accuracy of what was true when
  written) with a pointer to this reversal.
- `CHANGELOG.md` -- entry added per this repo's Keep-a-Changelog
  convention.
- Filed **#84** separately (not fixed here) for an unrelated
  discrepancy found during this work: upstream's own `init.sh`
  public-hosting reminder omits IGW UDP 7888-7921 even though the
  multi-server guide lists it as required -- deliberately out of scope
  for this PR per this project's own scope-creep discipline.

## Not done in this PR (explicit deferral)

- The actual UCG-Max port-forward/firewall configuration this
  describes -- manual, web-UI step, tracked as a follow-up once
  dune-dev's battlegroup is actually initialized (in progress in a
  live operator session as of this PR).
- Applying `multi-server-config.py apply --instance 2` itself against
  dune-dev's live checkout -- also a live follow-up once dune-dev's
  `dune init` completes.

## Docs reviewed

- `docs/02-network-setup.md` (this PR's subject)
- `docs/00-START-HERE.md`, `docs/03-runbook-day-of.md` -- checked for
  any other reference to the old Dev-no-forwards decision; none found
  outside `02-network-setup.md`.
