### PR TITLE
docs: fix values.env.example stale Dev-no-forwards comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ introduced them, in Keep a Changelog style, newest first.
 
 ### Changed
 
+- `docs/values.env.example`'s port-forward section still said "Dev is
+  intentionally NOT forwarded (LAN/VPN-only)" and only listed Prod's
+  variables — stale after PR #85 reversed that decision (Dev now gets
+  real WAN forwards via the multi-server guide's Instance 2, +1000
+  offset, profile). Updated the comment and added
+  `FORWARD_DEV_UDP_GAME_RANGE`/`FORWARD_DEV_TCP_RMQ_GAME`/
+  `FORWARD_DEV_TCP_RMQ_HTTP` (`8777-8810`/`32982`/`32983`), matching the
+  confirmed values in `docs/02-network-setup.md`. (#86)
+
 - `docs/02-network-setup.md` Step 5: reversed the prior "Dev gets no
   port forwards at all... LAN/VPN-only, no public testers" decision.
   Dev now gets real WAN port forwards using a distinct, collision-free

--- a/docs/values.env.example
+++ b/docs/values.env.example
@@ -56,11 +56,17 @@ FUNCOM_ACCOUNT_FOR_PROD=       # e.g. "account #1 - primary email"
 FUNCOM_ACCOUNT_FOR_DEV=        # e.g. "account #2 - secondary email"
 FUNCOM_ACCOUNT_SPARE=          # account #3, banked for a future 3rd battlegroup
 
-# --- Router port forwards (see docs/02-network-setup.md Step 4) ------------
-# Prod only. Dev is intentionally NOT forwarded (LAN/VPN-only).
+# --- Router port forwards (see docs/02-network-setup.md Step 4/5) ---------
+# Prod = Instance 1 (stock ports). Dev = Instance 2 (+1000 offset,
+# issue #83/#85 -- Dev now gets real WAN forwards, reversing the
+# earlier LAN/VPN-only decision).
 FORWARD_UDP_GAME_RANGE=7777-7810
 FORWARD_TCP_RMQ_GAME=31982
 FORWARD_TCP_RMQ_HTTP=31983
+
+FORWARD_DEV_UDP_GAME_RANGE=8777-8810
+FORWARD_DEV_TCP_RMQ_GAME=32982
+FORWARD_DEV_TCP_RMQ_HTTP=32983
 
 # --- Backup file naming (see scripts/06, scripts/04) ------------------------
 # Filled in on the day - just a place to jot the actual filename/checksum


### PR DESCRIPTION
Closes #86.

## Summary
PR #85 reversed the Dev-no-forwards decision — Dev now gets real WAN forwards via the multi-server guide's Instance 2 (+1000 offset) profile. `docs/values.env.example` was never updated to match: still said "Dev is intentionally NOT forwarded (LAN/VPN-only)" and only listed Prod's three forward variables.

## Risk classification
**Low.** Documentation-template-only fix. No script currently reads these variable names automatically (per the file's own header, it's a reference sheet, not sourced by anything) — but values need to be correct since operators/agents copy them verbatim into real deployments.

## What changed
- `docs/values.env.example`: updated the comment, added `FORWARD_DEV_UDP_GAME_RANGE`/`FORWARD_DEV_TCP_RMQ_GAME`/`FORWARD_DEV_TCP_RMQ_HTTP` matching the confirmed values in `docs/02-network-setup.md`.
- `CHANGELOG.md` updated.

## Verification
- `tests/no-personal-identifiers.sh` — clean
- `pre-commit run` — clean except the pre-existing, already-tracked (#29) unpinned-GitHub-Actions-tag finding in `.github/workflows/ci.yml`, confirmed untouched by this diff