### PR TITLE
docs: record issue #88 NTP firewall-exception review as rejected

### DIFF
--- a/compliance/eight-hats-findings-register.md
+++ b/compliance/eight-hats-findings-register.md
@@ -399,3 +399,67 @@ title at that number). **4 CRITICAL findings' content is permanently
 lost** (see the CRITICAL section's closing note) — treat "57" as this
 register's original, unverified aspiration, and "53" as its actual,
 audited content going forward.
+
+---
+
+## 2026-08-14 (separate review) — Issue #88: Prod/Dev VM NTP sync via Proxmox host — REJECTED
+
+This is a standalone Requirement 20 Layer 1 (design, pre-implementation)
+audit, unrelated to the 2026-08-07 review above — recorded here as this
+repo's established home for eight-hats findings, not folded into the
+counts/tables above.
+
+**Proposal:** give dune-prod/dune-dev a single internal NTP source (the
+Proxmox host) instead of each syncing from internet NTP pools directly.
+Required a new firewall policy: `Prod-Zone/Dev-Zone -> Internal: ALLOW,
+UDP/123, destination 192.168.68.127/32` — the first-ever initiated path
+from a battlegroup VM into the Internal zone (where Proxmox lives),
+reversing this project's own documented isolation intent (Step 4, rule
+5: "if a VM is ever compromised, this stops it from pivoting to the
+hypervisor layer").
+
+**Outcome: rejected, unanimously, by every applicable hat.** Full
+findings in issue #88's dispatched review. Summary:
+
+- **Architect:** solves a non-problem — all 4 hosts already synced
+  within 1-4ms of real UTC before this was proposed; no drift issue,
+  no incident. Trades resilience (each VM independently reachable to
+  the internet) for a new single-point dependency and East/West
+  exposure, for zero measured benefit.
+- **Security (CRITICAL):** directly reverses documented threat-model
+  intent with no compensating control. chrony has a real CVE history;
+  granting a `--privileged`, third-party-binary game-server VM (this
+  register's own C-2) a standing network path to the hypervisor's own
+  IP is a permanent, nonzero increase in hypervisor attack surface.
+- **GRC:** no risk-acceptance record existed prior to this entry (now
+  resolved by this entry existing). Separately flagged a process
+  inconsistency: the chrony *server-side* config on Proxmox was applied
+  live, before this review was requested — assessed as inert/low-risk
+  in isolation (nothing could reach it without the firewall rule, and
+  it was independently, cleanly reverted), but noted as a pattern not
+  to repeat: sensitive-host config changes should go through the same
+  review gate as the network change they're paired with, not be
+  treated as pre-approved because they're harmless standing alone.
+- **Network:** the proposed rule's narrowness (UDP/123, single /32) was
+  technically sound as written, but would have needed live
+  verification against the UniFi zone-firewall's actual behavior
+  before being trusted. The discarded alternative (second Proxmox IP
+  on the Mgmt VLAN) was independently found to be *worse*, not
+  equivalent — it dual-homes Proxmox across two zones instead of one,
+  multiplying its attack surface rather than relocating a single
+  exception.
+- Cloud Security / UI / DBA: not applicable, confirmed and stated why
+  in the full review.
+- **QA/Test:** no test plan or rollback procedure existed for the
+  firewall policy itself (only for the already-reverted chrony config),
+  independently sufficient to call this not implementation-ready even
+  setting the reject recommendation aside.
+
+**Remediation:** the already-applied Proxmox chrony server config
+(`/etc/chrony/conf.d/lan-ntp-server.conf`) was reverted the same
+session this review completed (`rm` + `systemctl restart chrony`,
+verified running afterward). No firewall policy change was ever
+applied — issue #88 caught this before implementation, exactly as
+Requirement 20's Layer 1 gate is meant to. Each VM continues syncing
+NTP from internet pools directly, unchanged from before this issue was
+opened.


### PR DESCRIPTION
## Risk classification

**None -- documentation only, records a rejection.** No firewall
policy was ever applied; the only live change made (Proxmox chrony
server config) has already been reverted and verified. This PR is
purely the durable evidence trail for that decision.

## Summary

Closes #88. Records the outcome of a dispatched eight-hats Layer 1
design review: **unanimous rejection** of giving dune-prod/dune-dev
NTP sync from the Proxmox host, since it required a new
Prod-Zone/Dev-Zone -> Internal firewall exception that would have
reversed this project's own documented VM-isolation intent, for a
benefit that doesn't exist (all 4 relevant hosts were already
NTP-synchronized within 1-4ms of real UTC before this was proposed --
confirmed live, not assumed).

## What actually happened, in order

1. Operator asked to configure NTP so both VMs use it, initially via
   the UCG-Max as the source.
2. Investigated: UCG-Max doesn't answer NTP queries on its LAN
   interface (verified via 3x direct UDP/123 probe, all timeout), and
   DHCP is disabled on Prod/Dev/Mgmt (static IPs only) so DHCP option
   42 can't reach any of them regardless.
3. Pivoted to "Proxmox as the single internal source" per operator's
   explicit choice. Applied Proxmox's server-side chrony config
   (`allow` directives) before realizing this required a firewall
   change.
4. Attempted to point dune-prod at Proxmox -- found dune-prod cannot
   reach Proxmox's IP at all (100% ping loss), confirmed via the live
   UniFi firewall policy table that only return-traffic is allowed in
   that zone direction, not VM-initiated connections.
5. Operator's own reaction: **"we should write this change up and have
   a review, fearful of east/west exposure"** -- filed #88, dispatched
   the eight-hats Layer 1 review before touching the firewall at all.
6. Review returned unanimous rejection across Architect/Security/GRC/
   Network/QA (Cloud Security/UI/DBA not applicable, confirmed).
7. Reverted the already-applied Proxmox chrony config the same
   session, verified `chronyd` still running correctly afterward.

## Validation performed

- Confirmed via direct network test that all 4 hosts (this dev
  machine, Proxmox, dune-prod, dune-dev) were already
  `chronyc`-synchronized within 1-4ms of each other and real UTC
  *before* any of this work started -- there was never an actual
  drift problem, only an architecture preference.
- Confirmed via 3x independent UDP/123 probes that the UCG-Max does
  not serve NTP on its LAN interface.
- Confirmed via the UniFi Integration API's live `dhcpd_enabled` field
  that Prod/Dev/Mgmt all have DHCP disabled (static-IP-only design),
  independently ruling out DHCP option 42 regardless of the UCG-Max's
  own NTP-serving capability.
- Confirmed via a real `ping` test (100% loss) and the live firewall
  policy table (queried via API, not assumed) that dune-prod cannot
  reach Proxmox's IP under the current zone model.
- Confirmed via `systemctl status chrony` that the revert (`rm
  /etc/chrony/conf.d/lan-ntp-server.conf && systemctl restart
  chrony`) left the service running correctly afterward.

## Scope

`compliance/eight-hats-findings-register.md` only -- adds a new,
clearly-delineated section for this standalone review (not folded
into the 2026-08-07 review's counts/tables above it, since it's an
unrelated audit event).

## Docs reviewed

- `docs/02-network-setup.md` Step 4 (the isolation model this
  proposal would have modified) -- confirmed still accurate, no
  update needed since no change was made to the live firewall.
- `compliance/eight-hats-findings-register.md` -- this PR's subject.
