### PR TITLE
docs: dedicated bot VM (VMID 103) on new Services VLAN 22 -- supersedes #92 and acp#166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ introduced them, in Keep a Changelog style, newest first.
 
 ## Unreleased
 
+### Added
+
+- **New "Services" VLAN (22) and dedicated bot VM design (VMID 103)**
+  for the ACP Discord bot — resolves the conflict between two earlier,
+  un-actioned proposals: `r740-dune-deployment-kit#92` (bot on
+  `dune-prod`) and `arrakis-control-panel#166` (bot directly on the
+  Proxmox host). Neither is used; the bot instead gets its own VM,
+  isolated from both the game-server VMs and the hypervisor itself.
+  `docs/02-network-setup.md` updated: Services network added to Step
+  1's table, `bridge-vids`, and the trunk port's tagged-networks list;
+  new `Services-Zone` and 5 new zone-matrix policies added to Step 4
+  (bot can reach both consoles' adapter APIs; neither game-server VM
+  or the hypervisor can be reached from the bot's zone); Step 5 (WAN
+  forwards) and Step 7 (verification) updated to cover the new VM.
+  Live gateway/bridge changes described are **not yet applied** as of
+  this writing — this is the design/documentation update; the actual
+  UniFi UI and Proxmox bridge config changes are a separate, tracked
+  follow-up. `prompts/r740xd/03-bot-deploy-and-tunnel.md`'s target IP
+  updated from `192.168.20.10` (dune-prod) to the new bot VM's address.
+  See issue #93 for the full decision record. (#93)
+
 ### Changed
 
 - `docs/values.env.example`'s port-forward section still said "Dev is

--- a/docs/02-network-setup.md
+++ b/docs/02-network-setup.md
@@ -29,6 +29,18 @@ the safe stopping points are if you need to pause partway through.
 **Status on this deployment (2026-08-12):** Steps 1, 3, and 4 are
 complete and independently verified.
 
+**Update (2026-08-17, issue #93):** a fourth VLAN, **Services (22)**, was
+added to Steps 1/2/3/4 below for the ACP Discord bot's dedicated VM
+(VMID 103). This supersedes two earlier, conflicting proposals to run
+the bot on `dune-prod` (`r740-dune-deployment-kit#92`) or directly on
+the Proxmox host (`arrakis-control-panel#166`) — see issue #93 for the
+full decision record. **Steps 1/2/3/4's Services additions below have
+NOT yet been applied to the live gateway/bridge** as of this writing
+(the original Prod/Dev/Mgmt work described immediately above was
+verified 2026-08-12, before this decision existed) — treat the
+Services-specific bullets in each step as a pending checklist item,
+not as already-done.
+
 Step 1: Prod, Dev, and Mgmt networks exist on the live gateway
 (confirmed via the UniFi Integration API); the existing
 Default/Trusted-LAN network was confirmed already correctly configured
@@ -115,7 +127,7 @@ step's scope and the Dev-specific port table.
 it already has an AP mesh and household devices behind it), Initial
 Setup is already done. Skip straight to Step 1.
 
-## Step 1: Create 3 New VLANs (Trusted-LAN Likely Already Exists)
+## Step 1: Create 4 New VLANs (Trusted-LAN Likely Already Exists)
 
 **Check first whether "Trusted-LAN" already exists before creating
 anything.** Every UniFi gateway ships with a built-in **"Default"**
@@ -139,7 +151,7 @@ actual existing gateway assigned) as "Trusted-LAN" in Step 4's firewall
 zone policies — the specific VLAN ID doesn't matter, only that it's
 distinct from Prod/Dev/Mgmt below, which it already is.
 
-**Create only these 3 new networks.** Go to **Settings → Networks →
+**Create only these 4 new networks.** Go to **Settings → Networks →
 Create New Network** for each. For each network, set "Network Purpose"
 to a **Corporate/Standard** network (not Guest — Guest networks have
 extra client-isolation restrictions you don't need here, and add
@@ -151,6 +163,7 @@ complexity to inter-VM communication if you ever want it).
 | Prod | 20 | 192.168.20.0/24 | dune-prod VM |
 | Dev | 21 | 192.168.21.0/24 | dune-dev VM |
 | Mgmt | 30 | 192.168.30.0/24 | Proxmox host, iDRAC |
+| Services | 22 | 192.168.22.0/24 | ACP Discord bot VM (VMID 103, issue #93) — deliberately its own network, not Prod/Dev/Mgmt; see the rationale in issue #93 (co-locating a public-facing bot with the game server or the hypervisor itself both increase blast radius for no benefit) |
 
 **This is unrelated to ongoing connectivity issues, if you have any.**
 If devices are dropping or reconnecting unpredictably independent of
@@ -189,10 +202,19 @@ iface vmbr0 inet manual
     bridge-stp off
     bridge-fd 0
     bridge-vlan-aware yes
-    bridge-vids 10 20 21 30
+    bridge-vids 10 20 21 22 30
 # After editing, apply:
 ifreload -a
 ```
+
+**Update (2026-08-17, issue #93):** VLAN 22 (Services) added to
+`bridge-vids` for the ACP bot VM. If your live `bridge-vids` line
+already has `20 21 30` from the original Prod/Dev/Mgmt setup, add `22`
+to it (order in the list doesn't matter) and re-run `ifreload -a` —
+this is a config-file edit + reload, not a full network restart, and
+does not require touching the bridge's IP or any existing VM's
+connectivity to verify: `qm config 101` / `qm config 102` should show
+unchanged `net0` lines after this change.
 
 **Without this setting, VLAN tags on VM network interfaces are silently
 ignored and both VMs fall onto the same untagged broadcast domain —
@@ -219,11 +241,11 @@ UniFi Network version) to:
 
 - **Native/Untagged Network**: leave unset, or set to none — this port
   should carry no untagged traffic
-- **Tagged Networks**: select all four — the existing Default/Trusted-LAN
+- **Tagged Networks**: select all five — the existing Default/Trusted-LAN
   network (whatever VLAN ID it already has, e.g. 1), Prod (20),
-  Dev (21), Mgmt (30)
+  Dev (21), Mgmt (30), and Services (22, added 2026-08-17 per issue #93)
 
-This makes the port an 802.1Q trunk carrying all four VLANs tagged.
+This makes the port an 802.1Q trunk carrying all five VLANs tagged.
 Do NOT split this into three separate access ports even if you have
 spare ports available — the VM NIC config on the Proxmox side uses
 `tag=20` and `tag=21`, which emit 802.1Q-tagged frames; a plain access
@@ -252,8 +274,9 @@ built-in **Internal** zone, and Internal→Internal traffic is
 each other and your Trusted-LAN devices freely, and why this step
 exists.
 
-**Recommended approach:** create three custom zones (e.g. `Prod-Zone`,
-`Dev-Zone`, `Mgmt-Zone`) and move the Prod, Dev, and Mgmt networks into
+**Recommended approach:** create four custom zones (e.g. `Prod-Zone`,
+`Dev-Zone`, `Mgmt-Zone`, `Services-Zone` — the fourth added 2026-08-17
+per issue #93) and move the Prod, Dev, Mgmt, and Services networks into
 them respectively (a network can only belong to one zone at a time,
 set when editing the network or in the Firewall/Zones section). Leave
 Trusted-LAN in the default **Internal** zone. Then, in the **Zone
@@ -271,18 +294,40 @@ depending on your UniFi Network version), configure:
    (neither battlegroup VM should be able to reach the Proxmox
    hypervisor or iDRAC — if a VM is ever compromised, this stops it
    from pivoting to the hypervisor layer)
-6. Leave every zone pair not listed above at its **default** value —
-   do not manually add a blanket "default deny" policy on top of the
-   zone matrix; the built-in per-zone defaults (e.g. External→Internal
-   already defaults to block-except-return-traffic) already provide
-   this, and adding a conflicting custom rule can produce confusing,
-   hard-to-debug interactions with the built-in policies.
+6. **Internal → Services-Zone: Allow** (so you can SSH into the bot VM
+   and manage it normally from your everyday devices — added 2026-08-17
+   per issue #93)
+7. **Services-Zone → Prod-Zone: Allow, Services-Zone → Dev-Zone: Allow**
+   (the ACP Discord bot is multi-tenant — one instance needs to reach
+   both consoles' adapter APIs at `192.168.20.10:8088` and
+   `192.168.21.10:8088`; see `r740xd/03-bot-deploy-and-tunnel.md`)
+8. **Prod-Zone → Services-Zone: Block, Dev-Zone → Services-Zone: Block**
+   (neither battlegroup VM has any reason to initiate a connection
+   *to* the bot — this is one-directional by design, same reasoning as
+   rule 5's hypervisor containment applied to the bot's own network)
+9. **Services-Zone → Mgmt-Zone: Block** (the bot VM must not reach the
+   Proxmox hypervisor or iDRAC either — same containment principle as
+   rule 5, applied to a third, independently-compromisable VM)
+10. Leave every zone pair not listed above at its **default** value —
+    do not manually add a blanket "default deny" policy on top of the
+    zone matrix; the built-in per-zone defaults (e.g. External→Internal
+    already defaults to block-except-return-traffic) already provide
+    this, and adding a conflicting custom rule can produce confusing,
+    hard-to-debug interactions with the built-in policies.
 
 **Double-check both directions for every rule.** Per Ubiquiti's own
 documentation, blocking Zone A → Zone B does not automatically block
 Zone B → Zone A — you must configure both directions explicitly, which
-is why rules 3/4 and the two halves of rule 5 are listed as separate
-entries above.
+is why rules 3/4, the two halves of rule 5, rule 7's two halves, and
+rule 8's two halves are all listed as separate entries above. Rule 9
+only lists `Services-Zone → Mgmt-Zone: Block`, not the reverse
+(`Mgmt-Zone → Services-Zone`) — this is a deliberate scope decision
+(the bot VM has nothing the Proxmox host itself needs to initiate a
+connection to), not an oversight, but **verify what the built-in
+default actually resolves to for that specific pair** before assuming
+it's already blocked; if the live Zone Matrix shows it as Allow by
+default and you want it blocked too, add it explicitly rather than
+relying on this note's assumption.
 
 **Do not block traffic to the built-in Gateway zone** for any of your
 new zones — this handles DHCP/DNS/management traffic for the UCG-Max
@@ -379,6 +424,14 @@ Cloudflare Tunnel with no additional access gate — don't reproduce that
 here without at least Cloudflare Access in front of it, see
 `04-post-standup-hardening.md`).
 
+**The Services VLAN's bot VM (192.168.22.x, issue #93) also gets no WAN
+port forward of any kind.** It's reached exclusively via the Cloudflare
+Tunnel (already the case for the bot's public-facing endpoints today,
+unchanged by this migration — see `r740xd/03-bot-deploy-and-tunnel.md`)
+and via VPN for direct SSH/admin access (Step 6, same pattern as the
+consoles). There is no scenario in this deployment where the bot VM
+needs a direct WAN-forwarded port.
+
 ## Step 6: VPN Access for Remote Admin
 
 Go to **Settings → VPN → Teleport** (Ubiquiti's zero-config WireGuard VPN)
@@ -405,6 +458,15 @@ directly to the WAN.
 3. Confirm the R740/Proxmox host still has connectivity after the
    Step 3 trunk-port change (re-check if you skipped the inline
    verification in that step).
+4. **Once the bot VM (VMID 103, issue #93) exists**: from the bot VM,
+   confirm it can reach both consoles (`curl` an adapter health-check
+   endpoint at `192.168.20.10:8088` and `192.168.21.10:8088`) and
+   confirm the reverse is blocked (from `dune-prod`/`dune-dev`, `ping
+   -c 3 -W 2 192.168.22.x` toward the bot VM's IP should fail per rule
+   8 above). Report actual output for both directions, not just the
+   Allow direction — a policy that silently fails to block is worse
+   than no policy, since it looks correct in the one direction anyone
+   normally tests.
 
 Once VLANs, firewall policies, port forwards, and the trunk port are in
 place and verified — and your existing devices/mesh are confirmed

--- a/prompts/r740xd/03-bot-deploy-and-tunnel.md
+++ b/prompts/r740xd/03-bot-deploy-and-tunnel.md
@@ -3,28 +3,111 @@
 You are an LLM coding agent running in your own session, executed from
 the dev machine's terminal via `ssh`/`scp` (there's no separate "log into
 the console and type these" step), but every actual change you make
-lands ON the dune-prod VM (`192.168.20.10`) — this is R740xd-side
-configuration work, not a Tabr-Tau gathering step, regardless of which
-physical keyboard you're typing on (see issue #59's session boundary).
-Your job in this session: rotate the bot's secrets off the values
-transferred from OCI, clone and deploy the bot, configure the Cloudflare
-Tunnel, apply security hardening, and run end-to-end verification.
+lands ON the dedicated bot VM (`192.168.22.10`, VMID 103, "Services"
+VLAN 22) — this is R740xd-side configuration work, not a Tabr-Tau
+gathering step, regardless of which physical keyboard you're typing on
+(see issue #59's session boundary). Your job in this session: provision
+the bot VM if it doesn't exist yet, rotate the bot's secrets off the
+values transferred from OCI, clone and deploy the bot, configure the
+Cloudflare Tunnel, apply security hardening, and run end-to-end
+verification.
+
+**Update (2026-08-17, issue #93):** this prompt previously targeted the
+`dune-prod` VM directly (`192.168.20.10`). That decision was reversed —
+co-locating a public-facing Discord bot process with the live game
+server increases blast radius for no benefit (if the bot is ever
+compromised, production is directly exposed). The bot now gets its own
+dedicated VM on a new "Services" VLAN, isolated from both game-server
+VMs and the Proxmox hypervisor itself — see issue #93 for the full
+decision record (which also rejected running the bot directly on the
+Proxmox host, `arrakis-control-panel#166`, for the same reason applied
+to the hypervisor's own risk profile).
 
 ## Target Machines
-- dune-prod VM (`dune@192.168.20.10`) — everything below changes state here
+- **Bot VM** (`bot@192.168.22.10`, VMID 103, "acp-bot") — everything
+  below changes state here. If this VM doesn't exist yet, see Phase 0
+  below (provisioning) before Phase 1.
 - The dev machine — only used as the SSH client; the user will also need
   browser access to the Discord Developer Portal and Cloudflare Zero
   Trust dashboard (Phase 1 and Phase 3.2) — you cannot drive those
   browser steps yourself, walk the user through them.
 
 ## Before You Start, Confirm
+- `docs/02-network-setup.md` Steps 1-4 completed for the Services VLAN
+  (22) specifically — network created, bridge-vids includes 22, trunk
+  port carries it, and the `Services-Zone` policies (issue #93) exist
+  and are verified in both directions, not just the Allow direction
 - `r740xd/02-game-servers.md` completed — both battlegroups initialized
+  (the bot needs both consoles' adapter APIs reachable, which requires
+  both VMs to already exist and be running)
 - `tabr-tau/00-prerequisites.md` completed — bot secrets staged locally
   to `~/r740-bot-backup/secrets/`, Discord/Funcom credentials ready in
   the user's password manager (that prompt only gathers/stages; it does
   not rotate or deploy anything — do not assume it did)
 - The user has Discord Developer Portal access ready (Phase 1)
 - The user has Cloudflare Zero Trust dashboard access ready (Phase 3.2)
+
+## Phase 0: Provision the Bot VM (if it doesn't exist yet)
+
+Follow the exact same pattern as `r740xd/01-proxmox-and-vms.md` Phase 3,
+scaled down for a Discord bot's actual resource needs (2 vCPU / 4 GB RAM
+is generous — this is not a resource-constrained sizing decision, purely
+an isolation one; see issue #93):
+
+```bash
+# On the Proxmox host, as root:
+qm create 103 \
+  --name acp-bot \
+  --memory 4096 \
+  --balloon 0 \
+  --cores 2 \
+  --sockets 1 \
+  --cpu host \
+  --net0 virtio,bridge=vmbr0,tag=22 \
+  --scsihw virtio-scsi-pci \
+  --scsi0 local-lvm:20 \
+  --ide2 local:iso/ubuntu-26.04-live-server-amd64.iso,media=cdrom \
+  --boot 'order=ide2;scsi0' \
+  --ostype l26 \
+  --agent enabled=1
+qm set 103 --onboot 1
+```
+
+Unlike `dune-prod`/`dune-dev`, this VM does **not** need NUMA-node CPU
+affinity pinning — 2 vCPUs for a Discord bot process has no meaningful
+NUMA locality concern, and pinning would only reduce the scheduler's
+flexibility for no latency benefit at this scale.
+
+Install Ubuntu Server 26.04 interactively via the Proxmox console
+(same process as `r740xd/01-proxmox-and-vms.md` Phase 3.2):
+- **Network**: Manual IPv4 — `192.168.22.10/24`, gateway `192.168.22.1`,
+  DNS `1.1.1.1`
+- **Profile**: username `bot`, hostname `acp-bot`, generate + store the
+  password in the user's password manager
+- **SSH**: Enable "Install OpenSSH server"
+
+Verify SSH access before proceeding to Phase 1:
+```bash
+ssh bot@192.168.22.10 "hostname && free -h | head -2 && nproc"
+# Expected: acp-bot, ~4 GB RAM, 2 CPUs
+```
+
+Also verify the Services-Zone firewall policies actually work as
+intended (per `docs/02-network-setup.md` Step 7 item 4) before
+proceeding — confirm both the Allow direction (bot → both consoles'
+`:8088`) and the Block direction (dune-prod/dune-dev → bot VM, and bot
+VM → Mgmt-Zone) with real commands, not just by reading the policy
+table back:
+```bash
+# From the bot VM -- both should succeed:
+ssh bot@192.168.22.10 "curl -s -o /dev/null -w '%{http_code}\n' http://192.168.20.10:8088"
+ssh bot@192.168.22.10 "curl -s -o /dev/null -w '%{http_code}\n' http://192.168.21.10:8088"
+
+# From dune-prod toward the bot VM -- should fail (blocked):
+ssh bot@192.168.22.10 "ping -c 3 -W 2 192.168.22.10; echo EXIT=\$?"
+```
+Report the actual output of all three checks — do not assume the
+firewall policy took effect just because it was created in the UI.
 
 ## Phase 1: Rotate Secrets Migrated from OCI (C-6 fix)
 
@@ -42,7 +125,9 @@ Ask the user to:
    setup below. Do not write it anywhere yet.
 
 ### 1.2 Rotate Discord OAuth Client Secret (CLOUD-03 fix)
-If multi-tenant mode uses `DISCORD_CLIENT_SECRET`, ask the user to:
+This deployment's multi-tenant mode uses `DISCORD_CLIENT_SECRET` for
+per-guild OAuth onboarding — not conditional here (see the Phase 2.1
+correction). Ask the user to:
 1. Go to Discord Developer Portal → OAuth2 → **Reset Client Secret**
 2. Give you the new secret — same as above, used in Phase 2.
 
@@ -61,32 +146,62 @@ Confirm the directory no longer exists after running this.
 ## Phase 2: Clone and Deploy the Bot
 
 ### 2.1 Clone the Repository
+
+**Correction (2026-08-17, issue #93):** this step previously set
+`DUNE_CONSOLE_API_URL=http://localhost:8088`, which assumed the bot
+runs in single-tenant mode co-located with one console on the same
+host. Neither assumption holds now: the bot runs in **multi-tenant
+mode** (`ACP_MULTI_TENANT=true`, confirmed live on OCI today), which
+resolves each guild's own console URL and adapter token from its SQLite
+`guilds` table per-call rather than from a single static `.env` value
+— and it no longer co-locates with either console at all, since it now
+lives on its own Services-VLAN VM. `DUNE_CONSOLE_API_URL` and
+`DUNE_DISCORD_ADAPTER_TOKEN` are single-tenant-mode-only fields (only
+read when `!multiTenant`) and should be left **unset** in `.env`, not
+pointed at `localhost` or either console's real IP — leaving a stale
+value here would be dead config, not a functional bug, but should not
+be carried forward to avoid confusion about which mode is actually
+active.
+
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 git clone https://github.com/yacketrj/arrakis-control-panel.git ~/arrakis-control-panel
 cd ~/arrakis-control-panel
 npm ci --omit=dev
 cp .env.example .env
 
-# Set the essential values (update with the real values)
-sed -i "s|^DUNE_CONSOLE_API_URL=.*|DUNE_CONSOLE_API_URL=http://localhost:8088|" .env
+# Set the essential values (update with the real values):
+# ACP_MULTI_TENANT=true (confirm this is set -- do NOT set
+#   DUNE_CONSOLE_API_URL or DUNE_DISCORD_ADAPTER_TOKEN; multi-tenant
+#   mode resolves these per-guild instead, see the correction above)
 # DISCORD_BOT_TOKEN: use the ROTATED value from Phase 1.1 above, NOT the
 #   original value staged from OCI in tabr-tau/00-prerequisites.md
 # DISCORD_CLIENT_ID: from tabr-tau/00-prerequisites.md (this one doesn't
 #   need rotation -- it's a public identifier, not a secret)
-# DISCORD_CLIENT_SECRET: use the ROTATED value from Phase 1.2 above, if
-#   multi-tenant mode is enabled
-# DUNE_DISCORD_ADAPTER_TOKEN: from tabr-tau/00-prerequisites.md
+# DISCORD_CLIENT_SECRET: use the ROTATED value from Phase 1.2 above
+# ACP_BASE_URL / ACP_OAUTH_REDIRECT_URI / ACP_STEAM_LINK_BASE_URL /
+#   STEAM_LINK_REDIRECT_URI: carry forward from OCI's current live
+#   config unchanged -- these are hostname-based (the Cloudflare Tunnel
+#   hostname), not host-IP-based, and do not change as part of this
+#   migration
 ENDSSH
 ```
 Set each `.env` value using the rotated secrets from Phase 1, not the
-original OCI-origin values — double-check this before moving on.
+original OCI-origin values — double-check this before moving on. If
+you are migrating an existing OCI `.env` rather than starting fresh,
+also **remove** `DUNE_CONSOLE_API_URL`, `DUNE_DISCORD_ADAPTER_TOKEN`,
+`CLOUDFLARE_ACCOUNT_ID`, and `KV_NAMESPACE_ID` if present — all four
+are confirmed dead/single-tenant-only config that should not be carried
+forward (see `arrakis-control-panel#166` for the verification that
+established this).
 
-### 2.2 Generate ACP_SECRETS_KEY (CLOUD-08 fix, if multi-tenant)
-If `ACP_MULTI_TENANT=true`, per-guild adapter tokens in the SQLite
-database are stored in plaintext unless this key is set:
+### 2.2 Generate ACP_SECRETS_KEY (CLOUD-08 fix)
+This deployment always runs `ACP_MULTI_TENANT=true` (confirmed live on
+OCI today, unchanged by this migration — see the Phase 2.1 correction
+above) — per-guild adapter tokens in the SQLite database are stored in
+plaintext unless this key is set, so this step is not conditional here:
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 cd ~/arrakis-control-panel
 KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
 echo "ACP_SECRETS_KEY=${KEY}" >> .env
@@ -99,7 +214,7 @@ the setup portal after this change.
 
 ### 2.3 Register Slash Commands
 ```bash
-ssh dune@192.168.20.10 "cd ~/arrakis-control-panel && npm run register"
+ssh bot@192.168.22.10 "cd ~/arrakis-control-panel && npm run register"
 ```
 Confirm the command output shows registration success with no errors —
 report the actual output, don't assume success.
@@ -116,7 +231,7 @@ coverage the dev machine's commits already get, rather than only
 catching issues later in CI:
 
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 cd ~/arrakis-control-panel
 python3 -m pip install --user pre-commit 2>/dev/null || sudo apt-get install -y pipx python3-pip && python3 -m pip install --user pre-commit
 pre-commit install
@@ -129,7 +244,7 @@ unsure rather than running it unconditionally.
 
 ### 2.5 Install and Enable Systemd Service
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 sudo cp ~/arrakis-control-panel/systemd/acp-bot.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable acp-bot.service
@@ -140,7 +255,7 @@ ENDSSH
 
 Confirm `systemctl status` shows `active (running)`. Check logs:
 ```bash
-ssh dune@192.168.20.10 "journalctl -u acp-bot -n 30 --no-pager"
+ssh bot@192.168.22.10 "journalctl -u acp-bot -n 30 --no-pager"
 ```
 Confirm the bot shows "Ready!" and connects to Discord's gateway — report
 the actual log lines, don't just assume it worked because the service
@@ -148,47 +263,85 @@ the actual log lines, don't just assume it worked because the service
 
 ## Phase 3: Configure Cloudflare Tunnel
 
-### 3.1 Add Ingress Rules (C-8 fix — Access is MANDATORY)
-Edit `/etc/cloudflared/config.yml` on the dune-prod VM:
+**Correction (2026-08-17, issue #93):** this phase previously had you
+install and run a *new* `cloudflared` daemon directly on the bot's
+target VM, with its own local `config.yml`. That doesn't match this
+deployment's actual, current tunnel architecture (see the Arrakis-Project
+README's Live Systems section): the `acp-console` tunnel already runs
+centrally on the **Proxmox host** (`cloudflared.service`, dashboard/API-
+managed — its local `/etc/cloudflared/config.yml` is kept for
+readability but does **not** itself control routing; the authoritative
+ingress list lives in Cloudflare's Tunnel Configuration API), and it
+already reaches both `dune-prod:8088` and `dune-dev:8088` remotely
+across VLANs without running anything on either VM. The bot VM should
+work the same way: add its ingress rule to the **existing** Proxmox-
+hosted tunnel, pointing at the bot VM's IP, rather than standing up a
+second tunnel daemon. This is also literally the migration this
+project's README already describes as the end state — folding the
+bot's separate OCI-hosted tunnel into the one Proxmox-hosted tunnel.
 
-```yaml
-tunnel: <your-tunnel-id>
-credentials-file: /home/dune/.cloudflared/<tunnel-id>.json
+### 3.1 Add Ingress Rules via the Cloudflare API (C-8 fix — Access is MANDATORY)
 
-ingress:
-  # Console admin — MUST have Cloudflare Access policy
-  - hostname: CONSOLE_TUNNEL_HOSTNAME
-    service: http://localhost:8088
+Do this from wherever you have Cloudflare API credentials configured
+(the dev machine, or the Proxmox host itself) — **not** by SSHing into
+the bot VM, since nothing needs to run there for this step:
 
-  # ACP setup portal + live stats API
-  - hostname: ACP_SETUP_TUNNEL_HOSTNAME
-    service: http://localhost:3100
-
-  # Steam OAuth callback (was missing — network engineer finding F3)
-  - hostname: ACP_SETUP_TUNNEL_HOSTNAME
-    path: /auth/steam
-    service: http://localhost:3101
-
-  # Catch-all
-  - service: http_status:404
-```
-
-**Coordinate this change carefully**: the same Cloudflare account's
-tunnel/DDNS infrastructure is shared with other independent services
-(e.g. the ACP landing page and other sites using the same Cloudflare DDNS
-setup). Before editing, confirm you are only adding new ingress rules for
-these hostnames, not modifying shared tunnel config that other services
-depend on — read the existing file first, don't overwrite it wholesale.
-
-Restart the tunnel:
 ```bash
-ssh dune@192.168.20.10 "sudo systemctl restart cloudflared && sudo systemctl status cloudflared"
+# Fetch the current tunnel configuration first -- do not skip this and
+# construct a new config from scratch, or you will silently drop every
+# other hostname (console, console-dev, landing, etc.) this tunnel
+# already serves.
+curl -s -X GET \
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${ACP_CONSOLE_TUNNEL_ID}/configurations" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" | jq . > /tmp/opencode/current-tunnel-config.json
 ```
-This restarts the ENTIRE tunnel daemon, not just these ingress rules —
-before restarting, confirm current status of every hostname/service
-sharing this tunnel and, per this project's Requirement 23 on documenting
-network ingress points, make sure the new ingress point ends up
-documented afterward.
+
+Add two new ingress rules to the fetched config's `ingress` array
+(inserted before the catch-all `http_status:404` rule, which must
+always remain last):
+
+```json
+{
+  "hostname": "ACP_SETUP_TUNNEL_HOSTNAME",
+  "service": "http://192.168.22.10:3100"
+},
+{
+  "hostname": "ACP_SETUP_TUNNEL_HOSTNAME",
+  "path": "/auth/steam",
+  "service": "http://192.168.22.10:3101"
+}
+```
+
+Then `PUT` the modified configuration back:
+```bash
+curl -s -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${ACP_CONSOLE_TUNNEL_ID}/configurations" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data @/tmp/opencode/modified-tunnel-config.json | jq .
+```
+
+**Coordinate this change carefully**: the same tunnel already serves
+`CONSOLE_TUNNEL_HOSTNAME` and its Dev-VM equivalent (both live
+game-server admin consoles). A `PUT` replaces the entire ingress list —
+always fetch-modify-PUT the full current config (as above), never
+construct a partial one, or you will silently take down every other
+hostname this tunnel serves. Verify with a follow-up `GET` (not just
+trusting the `PUT` response) that all pre-existing hostnames are still
+present alongside the two new ones before moving on.
+
+**This does not require restarting `cloudflared.service` on the Proxmox
+host** — per the README, this tunnel is dashboard/API-managed; a config
+API update takes effect without a daemon restart. If you need to
+confirm the daemon itself is still healthy after the API change (it
+should be, since nothing about the running process changed), you may
+optionally check `ssh root@<proxmox-mgmt-ip> "systemctl status
+cloudflared"`, but do not restart it as part of this step.
+
+Per this project's Requirement 23 on documenting network ingress
+points, update the Arrakis-Project README's Live Systems section to
+reflect the new `192.168.22.10:3100`/`:3101` ingress targets once this
+is live (see issue #93 for the tracking reference).
 
 ### 3.2 Enforce Cloudflare Access (C-8 — was "recommended", now MANDATORY)
 
@@ -223,10 +376,10 @@ and go back to step 1 above.
 ## Phase 4: Configure Database Backup (C-4 fix)
 
 ### 4.1 ACP SQLite Daily Backup
-Create a systemd timer on the dune-prod VM:
+Create a systemd timer on the bot VM:
 
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 sudo tee /etc/systemd/system/acp-db-backup.service << 'UNIT'
 [Unit]
 Description=ACP Bot SQLite Database Backup
@@ -234,11 +387,11 @@ After=network.target
 
 [Service]
 Type=oneshot
-User=dune
+User=bot
 ExecStart=/bin/bash -c '\
-  BACKUP_DIR="/home/dune/arrakis-control-panel/data/backups"; \
+  BACKUP_DIR="/home/bot/arrakis-control-panel/data/backups"; \
   mkdir -p "$BACKUP_DIR"; \
-  DB="/home/dune/arrakis-control-panel/data/acp.db"; \
+  DB="/home/bot/arrakis-control-panel/data/acp.db"; \
   if [ -f "$DB" ]; then \
     cp "$DB" "$BACKUP_DIR/acp-$(date +%%Y%%m%%d-%%H%%M%%S).db"; \
     find "$BACKUP_DIR" -name "acp-*.db" -mtime +30 -delete; \
@@ -265,7 +418,7 @@ ENDSSH
 
 Confirm:
 ```bash
-ssh dune@192.168.20.10 "ls -la ~/arrakis-control-panel/data/backups/ && systemctl list-timers acp-db-backup.timer"
+ssh bot@192.168.22.10 "ls -la ~/arrakis-control-panel/data/backups/ && systemctl list-timers acp-db-backup.timer"
 ```
 Report the actual backup file listing and timer status.
 
@@ -276,16 +429,28 @@ Ask the user to run `/dune server health` in their Discord server and
 report whether the bot responds with server status within 5 seconds.
 
 ### 5.2 Adapter Endpoint Verification
+
+**Correction (2026-08-17, issue #93):** this step previously assumed
+single-tenant mode with one static `DUNE_DISCORD_ADAPTER_TOKEN` and a
+co-located console at `localhost:8088`. In multi-tenant mode, each
+guild has its own console URL and adapter token stored in the bot's own
+`guilds` SQLite table — there is no single "the" adapter token to test
+directly. Verify per-guild connectivity instead, from an already-
+onboarded Discord guild (not from the VM's shell):
+
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
-# Test that the bot can reach the console adapter
-ADAPTER_TOKEN=$(grep DUNE_DISCORD_ADAPTER_TOKEN ~/arrakis-control-panel/.env | cut -d= -f2)
-curl -s -H "Authorization: Bearer ${ADAPTER_TOKEN}" \
-  http://localhost:8088/api/integrations/discord/health | jq .
-ENDSSH
+# From the bot VM, confirm network reachability to both consoles
+# (the actual per-guild adapter-token auth is exercised end-to-end by
+# the Discord command test in 5.1 above, not testable directly here
+# without a specific guild's stored token):
+ssh bot@192.168.22.10 "curl -s -o /dev/null -w 'dune-prod: %{http_code}\n' http://192.168.20.10:8088"
+ssh bot@192.168.22.10 "curl -s -o /dev/null -w 'dune-dev: %{http_code}\n' http://192.168.21.10:8088"
 ```
-Expected: `{"ok": true, ...}`. Report the actual response and flag any
-deviation.
+Expected: both return a real HTTP status (`200`/`302`/`401` are all
+"reachable" — anything other than a connection timeout/refused
+confirms the Services-Zone → Prod-Zone/Dev-Zone firewall policies from
+`docs/02-network-setup.md` Step 4 are working end-to-end for this VM,
+not just in the abstract). Report the actual codes.
 
 ### 5.3 Cloudflare Tunnel Verification
 ```bash
@@ -298,7 +463,8 @@ returns `302` or `200` (redirect to Access login is OK). Report actual
 results.
 
 ### 5.4 Firewall Isolation Verification
-From dune-dev VM, confirm Prod is unreachable:
+From dune-dev VM, confirm Prod is unreachable (pre-existing Prod/Dev
+isolation, unrelated to the bot VM):
 ```bash
 ssh dune@192.168.21.10 "ping -c 3 -W 2 192.168.20.10; echo EXIT=\$?"
 ```
@@ -307,10 +473,28 @@ is broken — stop, report this to the user, and go back to Phase 2.0 of
 `r740xd/01-proxmox-and-vms.md` to fix `bridge-vlan-aware` before
 continuing this prompt.**
 
+### 5.5 Services-Zone Isolation Verification (added 2026-08-17, issue #93)
+
+Confirm the bot's new zone policies actually hold, both directions —
+this was already checked once in Phase 0 before the bot software was
+even installed, but re-verify now that the full stack is live, since a
+Cloudflare Access policy or an application-level change earlier in this
+prompt could not have affected the network-layer firewall, but it's
+still worth confirming nothing changed:
+```bash
+# From dune-prod and dune-dev toward the bot VM -- both should fail:
+ssh dune@192.168.20.10 "ping -c 3 -W 2 192.168.22.10; echo EXIT=\$?"
+ssh dune@192.168.21.10 "ping -c 3 -W 2 192.168.22.10; echo EXIT=\$?"
+```
+Expected: both pings fail (non-zero exit). If either succeeds, the
+Services-Zone → Prod-Zone/Dev-Zone block rules (`docs/02-network-setup.md`
+Step 4, rule 8) are not actually in effect — stop, report this to the
+user, and go back to that step before considering this migration done.
+
 ## Phase 6: Deploy Remote Setup (for future git push deploys)
 
 ```bash
-ssh dune@192.168.20.10 << 'ENDSSH'
+ssh bot@192.168.22.10 << 'ENDSSH'
 mkdir -p ~/acp-deploy.git && cd ~/acp-deploy.git && git init --bare
 cp ~/arrakis-control-panel/scripts/deploy-post-receive.sh hooks/post-receive
 chmod +x hooks/post-receive
@@ -318,27 +502,42 @@ ENDSSH
 
 # On the dev machine, add the deploy remote:
 git -C ~/projects/acp/arrakis-control-panel remote add deploy \
-  ssh://dune@192.168.20.10/home/dune/acp-deploy.git
+  ssh://bot@192.168.22.10/home/bot/acp-deploy.git
 ```
 
 ## What to Report Back When This Prompt Is Done
 Confirm and explicitly report each of the following, not just "looks
 done":
+- Bot VM (VMID 103) provisioned on Services VLAN 22, or confirmed
+  already existing (Phase 0)
+- Services-Zone firewall policies verified in both directions (Phase 0
+  and 5.5) — not just the Allow direction
 - Discord bot token rotated (C-6)
-- OAuth client secret rotated if multi-tenant (CLOUD-03)
+- OAuth client secret rotated (CLOUD-03)
 - Staged secrets backup shredded on the dev machine
-- ACP_SECRETS_KEY generated if multi-tenant (CLOUD-08)
-- ACP bot cloned, installed, running on dune-prod VM
+- ACP_SECRETS_KEY generated (CLOUD-08) — multi-tenant mode is always
+  on for this deployment, this is not conditional
+- `.env` confirmed to NOT contain `DUNE_CONSOLE_API_URL` or
+  `DUNE_DISCORD_ADAPTER_TOKEN` (single-tenant-only, dead in this
+  deployment's multi-tenant mode — see the Phase 2.1 correction)
+- ACP bot cloned, installed, running on the bot VM
 - Systemd service `acp-bot.service` active and enabled
-- Cloudflare Tunnel ingress rules configured (incl. Steam port 3101)
+- Cloudflare Tunnel ingress rules added to the **existing**
+  Proxmox-hosted `acp-console` tunnel via the Configuration API (incl.
+  Steam port 3101) — confirmed via a follow-up GET that pre-existing
+  hostnames (console, console-dev) are still present, not just that
+  the two new rules were added
 - Cloudflare Access MANDATORY policy confirmed in front of
   CONSOLE_TUNNEL_HOSTNAME (confirmed via the user's incognito test, not
   assumed)
 - SQLite daily backup timer created and active (C-4)
 - Bot responds to slash commands in Discord
-- All adapter endpoints verified
-- VLAN isolation verified (ping from Dev to Prod failed as expected)
-- Deploy remote configured
+- Bot's network reachability to both consoles verified (5.2)
+- Prod/Dev VLAN isolation verified (ping from Dev to Prod failed as
+  expected, 5.4)
+- Services-Zone isolation verified (ping from Prod/Dev to the bot VM
+  both failed as expected, 5.5)
+- Deploy remote configured, pointing at the bot VM (not dune-prod)
 
 ## When This Prompt Is Done
 Tell the user to start a NEW, separate session on the dev machine and


### PR DESCRIPTION
## Summary
Resolves the conflict between two competing, un-actioned proposals for where the ACP Discord bot should live after leaving OCI:
- `r740-dune-deployment-kit#92` (dune-prod VM)
- `arrakis-control-panel#166` (Proxmox host directly)

Neither is used. The bot gets its own dedicated VM (VMID 103, "acp-bot"), on a new "Services" VLAN (22), isolated from both game-server VMs and the Proxmox hypervisor. See issue #93 for the full decision record.

## What changed

**`docs/02-network-setup.md`:**
- Services network (VLAN 22, `192.168.22.0/24`) added to Step 1's table, `bridge-vids`, and the trunk port's tagged-networks list
- New `Services-Zone` + 5 new zone-matrix policies added to Step 4: bot can reach both consoles' adapter APIs (`Services-Zone → Prod-Zone/Dev-Zone: Allow`); neither game-server VM nor the hypervisor can reach the bot (`Prod-Zone/Dev-Zone → Services-Zone: Block`, `Services-Zone → Mgmt-Zone: Block`)
- Step 5 (WAN forwards) and Step 7 (verification) updated to cover the new VM — no WAN port forward for the bot (Tunnel + VPN only, same pattern as the consoles)

**`prompts/r740xd/03-bot-deploy-and-tunnel.md`:** retargeted from `dune-prod` (`192.168.20.10`) to the new bot VM (`192.168.22.10`). Also fixes 4 real, pre-existing bugs found while updating this doc:
1. Assumed single-tenant mode (`DUNE_CONSOLE_API_URL=http://localhost:8088`) despite the bot actually running multi-tenant in production (confirmed via `arrakis-control-panel#166`'s own verified findings) — corrected to leave those fields unset per multi-tenant's per-guild resolution model
2. Cloudflare Tunnel phase had you stand up a *second* `cloudflared` daemon on the target VM, when the real architecture (per the account's own README) already runs one centrally on the Proxmox host, dashboard/API-managed, reaching both VMs remotely with nothing installed on either — corrected to add ingress via the existing tunnel's Configuration API instead
3. Systemd backup service still said `User=dune` / `/home/dune/` — corrected to the new VM's actual user
4. Deploy-remote git path still said `/home/dune/acp-deploy.git` — corrected

Also corrected `Arrakis-Project/README.md`'s Live Systems section (separate meta-repo commit, not in this PR) — it referenced this exact `#92`/dune-prod plan as the "Planned direction" for tunnel consolidation.

**`CHANGELOG.md`**: entry documenting all of the above.

## Scope

This PR is **documentation/design only** — it does not provision the VM, configure the live UCG-Max gateway, or touch the live Cloudflare Tunnel. Those are the next execution steps once this design is approved, tracked under issue #93.

## Test evidence

Doc-only change (no scripts touched), so `shellcheck`/`bash-syntax` gates are moot for this diff. Ran the repo's real checks:
- `bash tests/no-personal-identifiers.sh` — **passed** (caught and fixed one real leak I introduced: `console.darkdante.org` written literally instead of the repo's own `CONSOLE_TUNNEL_HOSTNAME` placeholder convention)
- Broken-relative-link check (mirrors CI's `markdown-lint` job logic) — 0 broken links in `docs/*.md`/`README.md`
- `gitleaks protect --staged` — no leaks found
- Full `pre-commit run` — all hooks passed for this diff (one `semgrep` finding exists in the repo, on `.github/workflows/ci.yml`'s unpinned action tags — confirmed via `git diff` that this PR does not touch that file at all; pre-existing, unrelated tech debt)

## Eight Hats summary
- **Architect**: follows the exact existing pattern (`docs/02-network-setup.md`'s Prod/Dev/Mgmt VLAN+zone structure, `01-proxmox-and-vms.md`'s VM-provisioning pattern) rather than introducing a new convention. Isolates the bot from both failure domains it would otherwise share fate with.
- **Security**: this is the core motivation — prevents a compromised public-facing Discord bot process from having direct network access to either the production game server or the hypervisor managing all VMs. Access enforcement (Cloudflare Access, path-scoped) carried forward unchanged from #166's own analysis.
- **GRC**: full decision record in issue #93, explaining why both prior proposals were rejected; CHANGELOG entry as durable evidence; README corrected in the same session rather than left to drift (Requirement 14).
- **Network**: new VLAN placement reasoned through explicitly (why not Mgmt, why not Prod/Dev); zone-matrix policies specify both directions where required, consistent with the existing doc's own stated Ubiquiti behavior (blocking A→B doesn't block B→A).
- **Cloud Security**: Cloudflare Tunnel Configuration API usage corrected to properly fetch-modify-PUT the full existing config rather than assume a fresh one, preventing an accidental takedown of the two live console hostnames sharing that tunnel.
- **UI**: N/A — no user-facing UI change, this is infrastructure/ops documentation only.
- **DBA**: N/A — no schema/persistence change.
- **QA/Test**: verified against this repo's actual CI-equivalent checks (personal-identifier guard, broken-link check, gitleaks, pre-commit) since there's no bats/unit-test suite applicable to markdown docs.

## Follow-ups (not in this PR, tracked in #93)
- Actual VM provisioning (`qm create` for VMID 103)
- Live UCG-Max UI changes (network, zone, policy creation)
- Live Cloudflare Tunnel Configuration API update
- `/api/alerts/relay`'s missing authentication (carried over from #166, recommended before tunnel repoint)

Closes (partially) #93 — the design/documentation is done; the live execution steps remain separate follow-up work.
