### PR TITLE
docs: fix Phase 6 missing deploy remote on bot VM's own clone

### DIFF
--- a/prompts/r740xd/03-bot-deploy-and-tunnel.md
+++ b/prompts/r740xd/03-bot-deploy-and-tunnel.md
@@ -500,10 +500,38 @@ cp ~/arrakis-control-panel/scripts/deploy-post-receive.sh hooks/post-receive
 chmod +x hooks/post-receive
 ENDSSH
 
-# On the dev machine, add the deploy remote:
-git -C ~/projects/acp/arrakis-control-panel remote add deploy \
+# On the dev machine, add the deploy remote (path corrected 2026-08-17,
+# issue #95 -- the dev machine's real, current clone layout is a flat
+# ~/projects/repos/, not ~/projects/acp/; see Arrakis-Project#27/#28):
+git -C ~/projects/repos/arrakis-control-panel remote add deploy \
   ssh://bot@192.168.22.10/home/bot/acp-deploy.git
+
+# CRITICAL, previously missing step (issue #95): the bot VM's OWN
+# working-tree clone (~/arrakis-control-panel) also needs a `deploy`
+# remote, pointing back at the local bare repo -- the post-receive
+# hook's own `git fetch deploy "$DEPLOY_BRANCH"` step depends on this
+# remote existing, and nothing above this point creates it. Confirmed
+# via real reproduction: the first actual `git push deploy deploy`
+# against a bot VM set up by this exact procedure failed at this step
+# with `fatal: 'deploy' does not appear to be a git repository` --
+# caught and fixed live, then folded back into this prompt so the next
+# VM build doesn't hit the same gap.
+ssh bot@192.168.22.10 << 'ENDSSH'
+cd ~/arrakis-control-panel && git remote add deploy ~/acp-deploy.git
+ENDSSH
 ```
+
+**Verify this phase actually works, not just that the commands ran
+without error** -- do a real test push (`git push deploy main:deploy`
+from the dev machine) and confirm the hook completes end-to-end (test
+suite runs, service restarts, `systemctl status acp-bot.service` shows
+`active`). A remote being *configured* does not prove a deploy will
+actually *succeed* -- the `WORK_DIR` path inside
+`scripts/deploy-post-receive.sh` must also match this VM's real user
+(`bot`) and home directory, which is a separate thing to verify (see
+`arrakis-control-panel#174` for a real case where this specific path
+had drifted and the only reason it was caught was a real test deploy,
+not a code review).
 
 ## What to Report Back When This Prompt Is Done
 Confirm and explicitly report each of the following, not just "looks
@@ -522,6 +550,11 @@ done":
   deployment's multi-tenant mode — see the Phase 2.1 correction)
 - ACP bot cloned, installed, running on the bot VM
 - Systemd service `acp-bot.service` active and enabled
+- **Deploy remote configured on BOTH ends** (dev machine's clone AND
+  the bot VM's own working-tree clone -- the latter is easy to miss,
+  see Phase 6's correction) **and verified with a real test push**,
+  not just "the remote-add commands ran" -- confirm the hook actually
+  completed (tests ran, service restarted, `active`) end-to-end
 - Cloudflare Tunnel ingress rules added to the **existing**
   Proxmox-hosted `acp-console` tunnel via the Configuration API (incl.
   Steam port 3101) — confirmed via a follow-up GET that pre-existing


### PR DESCRIPTION
Closes #95

## Risk classification: None (documentation only)

**Blast radius:** Zero -- this PR touches only a prompt doc's prose/commands. No infrastructure was changed by this PR itself; the fix was already applied live to the real bot VM as part of verifying `arrakis-control-panel#174`/`#175`, and this PR just folds that fix back into the reusable prompt so a future VM rebuild doesn't hit the same gap.

## What & why

Phase 6 (Deploy Remote Setup) only ever configured a `deploy` remote on the **dev machine's** clone, pointing at the bot VM's bare repo. It never configured a `deploy` remote on the **bot VM's own working-tree clone**, pointing back at the local bare repo -- but `scripts/deploy-post-receive.sh`'s hook logic (`git fetch deploy "$DEPLOY_BRANCH"`) depends on exactly that remote existing.

**Confirmed via real reproduction, not hypothetical**: the first actual `git push deploy deploy` against the real bot VM (`192.168.22.10`) failed with `fatal: 'deploy' does not appear to be a git repository` -- caught during `arrakis-control-panel#174`/`#175`'s live verification deploy (with the repo owner's explicit approval for that single-guild production instance), fixed live on the VM (`ssh bot@192.168.22.10 "cd ~/arrakis-control-panel && git remote add deploy ~/acp-deploy.git"`), after which the deploy succeeded end-to-end (71/71 tests, slash commands re-registered, service restarted, confirmed active).

Also corrected the dev-machine clone path from the stale `~/projects/acp/arrakis-control-panel` to the real, current `~/projects/repos/arrakis-control-panel` (per `Arrakis-Project#27`/`#28`'s directory-layout correction), and added an explicit "verify with a real test push" note plus a matching "What to Report Back" checklist item.

## Documentation reviewed
This PR *is* the documentation fix. No other doc in this repo references Phase 6's deploy-remote setup in a way that would also need updating.

## Eight Hats summary
- **Architect/Security/GRC/Network/Cloud Security/UI/DBA**: N/A -- zero-risk doc-only change.
- **QA**: The fix this doc now describes was independently verified against the real, live target before being written here (not just theorized) -- see `arrakis-control-panel#174`/`#175` for the full verification trail.

## Note on an unrelated, pre-existing local pre-commit finding
Running `pre-commit run` locally on this branch surfaces a semgrep finding (`github-actions-mutable-action-tag`) in `.github/workflows/ci.yml` -- confirmed pre-existing (untouched by this diff, present on `main` at `09d69185`) and not blocking `main`'s own CI (last 3 runs on `main` are green). Not fixed in this PR since it's unrelated to this doc change; flagging here rather than silently ignoring it, per Requirement 14.
